### PR TITLE
reduction has no value property, it is read-only float

### DIFF
--- a/compressor-example/index.html
+++ b/compressor-example/index.html
@@ -43,7 +43,6 @@ var compressor = audioCtx.createDynamicsCompressor();
 compressor.threshold.value = -50;
 compressor.knee.value = 40;
 compressor.ratio.value = 12;
-compressor.reduction.value = -20;
 compressor.attack.value = 0;
 compressor.release.value = 0.25;
 


### PR DESCRIPTION
note that this should also be changed on the MDN [DynamicCompressorNode](https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode) docs. I tried to edit that myself but it appears to be linking to a local example which isn't accessible to contributors through the editing interface.