### PR TITLE
Fixes mdn/content#9451 - Thanks @DrTechDaddy

### DIFF
--- a/audiocontext-states/index.html
+++ b/audiocontext-states/index.html
@@ -40,6 +40,9 @@
     startBtn.setAttribute('disabled','disabled');
     susresBtn.removeAttribute('disabled');
     stopBtn.removeAttribute('disabled');
+    
+    // Refresh the label from any previous 'Resume context'
+    susresBtn.textContent = 'Suspend context';
 
     // create web audio api context
     AudioContext = window.AudioContext || window.webkitAudioContext;


### PR DESCRIPTION
See https://github.com/mdn/content/issues/9451 

The sequence `Create context; Suspend context; Stop context; ` leaves the label of the `susresBtn` as `Resume context`

The proposed fix refreshes the label on Start

