### PR TITLE
Update audio-analyser example to modern JS

### DIFF
--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -1,169 +1,163 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>createMediaStreamSource example</title>
+    <title>Web Audio API examples: createMediaStreamSource()</title>
 
     <style>
-        #canvas {
-            margin-left: auto;
-            margin-right: auto;
-            display: block;
-            background-color: black;
-        }
-        #controls {
-            text-align: center;
-        }
-        #start_button, #stop_button {
-            font-size: 16pt;
-        }
-        #msg {
-            text-align: center;
-        }
+      #canvas {
+        margin-left: auto;
+        margin-right: auto;
+        display: block;
+        background-color: black;
+      }
+      #controls {
+        text-align: center;
+      }
+      #start_button,
+      #stop_button {
+        font-size: 16pt;
+      }
+      #msg {
+        text-align: center;
+      }
     </style>
   </head>
 
   <body>
-        <canvas id="canvas" width="512" height="256" ></canvas>
+    <canvas id="canvas" width="512" height="256"></canvas>
 
-        <p id="controls">
-          <input type="button" id="start_button" value="Start">
-          &nbsp; &nbsp;
-          <input type="button" id="stop_button" value="Stop">
-          <p id="msg"></p>
-        </p>
+    <div id="controls">
+      <input type="button" id="start_button" value="Start" />
+      &nbsp; &nbsp;
+      <input type="button" id="stop_button" value="Stop" />
+      <p id="msg"></p>
+    </div>
 
-        <script>
-            // Hacks to deal with different function names in different browsers
-            window.requestAnimFrame = (function(){
-              return  window.requestAnimationFrame       ||
-                      window.webkitRequestAnimationFrame ||
-                      window.mozRequestAnimationFrame    ||
-                      function(callback, element){
-                        window.setTimeout(callback, 1000 / 60);
-                      };
-            })();
-            window.AudioContext = (function(){
-                return  window.webkitAudioContext || window.AudioContext || window.mozAudioContext;
-            })();
-            // Global Variables for Audio
-            let audioContext;
-            let audioBuffer;
-            let sourceNode;
-            let analyserNode;
-            let javascriptNode;
-            let audioData = null;
-            let audioPlaying = false;
-            let sampleSize = 1024;  // number of samples to collect before analyzing data
-            let amplitudeArray;     // array to hold time domain data
-            // This must be hosted on the same server as this page - otherwise you get a Cross Site Scripting error
-            let audioUrl = "viper.mp3";
-            // Global variables for the Graphics
-            let canvasWidth  = 512;
-            let canvasHeight = 256;
-            let ctx;
+    <script>
+      // Global variables for audio
+      let audioContext;
+      let audioBuffer;
+      let sourceNode;
+      let analyserNode;
+      let javascriptNode;
+      let audioData = null;
+      let audioPlaying = false;
+      let sampleSize = 1024; // number of samples to collect before analyzing data
+      let amplitudeArray; // array to hold time domain data
+      // This must be hosted on the same server as this page - otherwise you get a Cross Site Scripting error
+      let audioUrl = "viper.mp3";
+      // Global variables for the Graphics
+      let canvasWidth = 512;
+      let canvasHeight = 256;
+      let ctx;
 
-            ctx = document.querySelector('#canvas').getContext('2d');
+      ctx = document.querySelector("#canvas").getContext("2d");
 
-            // When the Start button is clicked, finish setting up the audio nodes, play the sound,
-            // gather samples for the analysis, update the canvas
-            document.querySelector('#start_button').addEventListener('click', function(e) {
-                // the AudioContext is the primary 'container' for all your audio node objects
-                if(!audioContext) {
-                  try {
-                      audioContext = new AudioContext();
-                  } catch(e) {
-                      alert('Web Audio API is not supported in this browser');
-                  }
-                }
+      // When the Start button is clicked, finish setting up the audio nodes, play the sound,
+      // gather samples for the analysis, update the canvas
+      document.querySelector("#start_button").addEventListener("click", (e) => {
+        // the AudioContext is the primary 'container' for all your audio node objects
+        if (!audioContext) {
+          try {
+            audioContext = new AudioContext();
+          } catch (e) {
+            document.getElementById("msg").textContent("Web Audio API is not supported in this browser");
+          }
+        }
 
-                e.preventDefault();
-                // Set up the audio Analyser, the Source Buffer and javascriptNode
-                setupAudioNodes();
-                // setup the event handler that is triggered every time enough samples have been collected
-                // trigger the audio analysis and draw the results
-                javascriptNode.onaudioprocess = function () {
-                    // get the Time Domain data for this sample
-                    analyserNode.getByteTimeDomainData(amplitudeArray);
-                    // draw the display if the audio is playing
-                    if (audioPlaying == true) {
-                        requestAnimFrame(drawTimeDomain);
-                    }
-                }
-                // Load the Audio the first time through, otherwise play it from the buffer
-                if(audioData == null) {
-                    loadSound(audioUrl);
-                } else {
-                    playSound(audioData);
-                }
-            });
+        e.preventDefault();
+        // Set up the audio Analyser, the Source Buffer and javascriptNode
+        setupAudioNodes();
+        // setup the event handler that is triggered every time enough samples have been collected
+        // trigger the audio analysis and draw the results
+        javascriptNode.onaudioprocess = () => {
+          // get the Time Domain data for this sample
+          analyserNode.getByteTimeDomainData(amplitudeArray);
+          // draw the display if the audio is playing
+          if (audioPlaying) {
+            requestAnimationFrame(drawTimeDomain);
+          }
+        };
+        // Load the Audio the first time through, otherwise play it from the buffer
+        if (audioData === null) {
+          loadSound(audioUrl);
+        } else {
+          playSound(audioData);
+        }
+      });
 
-            // Stop the audio playing
-            document.querySelector('#stop_button').addEventListener('click', function(e) {
-                e.preventDefault();
-                sourceNode.stop(0);
-                audioPlaying = false;
-            });
+      // Stop the audio playing
+      document.querySelector("#stop_button").addEventListener("click", (e) => {
+        e.preventDefault();
+        sourceNode.stop(0);
+        audioPlaying = false;
+      });
 
+      function setupAudioNodes() {
+        sourceNode = new AudioBufferSourceNode(audioContext);
+        analyserNode = new AnalyserNode(audioContext);
+        javascriptNode = audioContext.createScriptProcessor(sampleSize, 1, 1);
+        // Create the array for the data values
+        amplitudeArray = new Uint8Array(analyserNode.frequencyBinCount);
 
-            function setupAudioNodes() {
-                sourceNode     = audioContext.createBufferSource();
-                analyserNode   = audioContext.createAnalyser();
-                javascriptNode = audioContext.createScriptProcessor(sampleSize, 1, 1);
-                // Create the array for the data values
-                amplitudeArray = new Uint8Array(analyserNode.frequencyBinCount);
-                // Now connect the nodes together
-                sourceNode.connect(audioContext.destination);
-                sourceNode.connect(analyserNode);
-                analyserNode.connect(javascriptNode);
-                javascriptNode.connect(audioContext.destination);
-            }
-            // Load the audio from the URL via Ajax and store it in global variable audioData
-            // Note that the audio load is asynchronous
-            function loadSound(url) {
-                document.getElementById('msg').textContent = "Loading audio...";
-                let request = new XMLHttpRequest();
-                request.open('GET', url, true);
-                request.responseType = 'arraybuffer';
-                // When loaded, decode the data and play the sound
-                request.onload = function () {
-                    audioContext.decodeAudioData(request.response, function (buffer) {
-                        document.getElementById('msg').textContent = "Audio sample download finished";
-                        audioData = buffer;
-                        playSound(audioData);
-                    }, onError);
-                }
-                request.send();
-            }
+        // Now connect the nodes together
+        sourceNode.connect(audioContext.destination);
+        sourceNode.connect(analyserNode);
+        analyserNode.connect(javascriptNode);
+        javascriptNode.connect(audioContext.destination);
+      }
 
-            // Play the audio and loop until stopped
-            function playSound(buffer) {
-                sourceNode.buffer = buffer;
-                sourceNode.start(0);    // Play the sound now
-                sourceNode.loop = true;
-                audioPlaying = true;
-            }
+      // Load the audio from the URL via XHR and store it in global variable audioData
+      // Note that the audio load is asynchronous
+      function loadSound(url) {
+        document.getElementById("msg").textContent = "Loading audio...";
+        let request = new XMLHttpRequest();
+        request.open("GET", url, true);
+        request.responseType = "arraybuffer";
+        // When loaded, decode the data and play the sound
+        request.onload =  () => {
+          audioContext.decodeAudioData(
+            request.response,
+            (buffer) => {
+              document.getElementById("msg").textContent =
+                "Audio sample download finished";
+              audioData = buffer;
+              playSound(audioData);
+            },
+            onError
+          );
+        };
+        request.send();
+      }
 
-            function onError(e) {
-                console.log(e);
-            }
+      // Play the audio and loop until stopped
+      function playSound(buffer) {
+        sourceNode.buffer = buffer;
+        sourceNode.start(0); // Play the sound now
+        sourceNode.loop = true;
+        audioPlaying = true;
+      }
 
-            function drawTimeDomain() {
-                clearCanvas();
-                for (let i = 0; i < amplitudeArray.length; i++) {
-                    let value = amplitudeArray[i] / 256;
-                    let y = canvasHeight - (canvasHeight * value) - 1;
-                    ctx.fillStyle = '#ffffff';
-                    ctx.fillRect(i, y, 1, 1);
-                }
-            }
+      function onError(e) {
+        console.error(e);
+      }
 
-            function clearCanvas() {
-                ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-            }
-        </script>
-    </body>
+      function drawTimeDomain() {
+        clearCanvas();
+        for (let i = 0; i < amplitudeArray.length; i++) {
+          let value = amplitudeArray[i] / 256;
+          let y = canvasHeight - canvasHeight * value - 1;
+          ctx.fillStyle = "#ffffff";
+          ctx.fillRect(i, y, 1, 1);
+        }
+      }
+
+      function clearCanvas() {
+        ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+      }
+    </script>
+  </body>
 </html>

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -88,17 +88,13 @@
                   // Get the canvas 2d context
                   const canvasContext = canvasElt.getContext("2d");
 
-                  // Define canvas size
-                  const canvasHeight = 512;
-                  const canvasWidth = 256;
-
                   // Clear the canvas
-                  canvasContext.clearRect(0, 0, canvasHeight, canvasWidth);
+                  canvasContext.clearRect(0, 0, canvasElt.height, canvasElt.width);
 
                   // Draw the amplitude inside the canvas
                   for (let i = 0; i < amplitudeArray.length; i++) {
                     let value = amplitudeArray[i] / 256;
-                    let y = canvasHeight - canvasHeight * value - 1;
+                    let y = canvasElt.height - canvasElt.weight * value - 1;
                     canvasContext.fillStyle = "#ffffff";
                     canvasContext.fillRect(i, y, 1, 1);
                   }

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -8,20 +8,7 @@
 
     <style>
       #canvas {
-        margin-left: auto;
-        margin-right: auto;
-        display: block;
         background-color: black;
-      }
-      #controls {
-        text-align: center;
-      }
-      #start_button,
-      #stop_button {
-        font-size: 16pt;
-      }
-      #msg {
-        text-align: center;
       }
     </style>
   </head>

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -32,8 +32,8 @@
       const stopBtn = document.querySelector("#stop_button");
       const canvasElt = document.querySelector("#canvas");
 
-      // When the Start button is clicked, finish setting up the audio nodes, play the sound,
-      // gather samples for the analysis, update the canvas
+      // When the _Start_ button is clicked, set up the audio nodes, play the sound,
+      // gather samples for the analysis, update the canvas.
       startBtn.addEventListener("click", (e) => {
         e.preventDefault();
         startBtn.disabled = true;

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -43,6 +43,7 @@
       const msg = document.querySelector("output");
       const startBtn = document.querySelector("#start_button");
       const stopBtn = document.querySelector("#stop_button");
+      const canvasElt = document.querySelector("#canvas");
 
       // When the Start button is clicked, finish setting up the audio nodes, play the sound,
       // gather samples for the analysis, update the canvas
@@ -98,7 +99,7 @@
                   // Draw the time domain in the canvas
 
                   // Get the canvas 2d context
-                  const canvasContext = document.querySelector("#canvas").getContext("2d");
+                  const canvasContext = canvasElt.getContext("2d");
 
                   // Define canvas size
                   const canvasHeight = 512;

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
 
-    <title>Web Audio API examples: createMediaStreamSource()</title>
+    <title>Web Audio API examples: audio analyser</title>
 
     <style>
       #canvas {
@@ -27,137 +27,112 @@
   </head>
 
   <body>
+    <h1>Web Audio API examples: audio analyser</h1>
     <canvas id="canvas" width="512" height="256"></canvas>
 
     <div id="controls">
       <input type="button" id="start_button" value="Start" />
       &nbsp; &nbsp;
-      <input type="button" id="stop_button" value="Stop" />
-      <p id="msg"></p>
+      <input type="button" id="stop_button" value="Stop" disabled/>
+      <br/><br/>
+      <output id="msg"></output>
     </div>
 
     <script>
-      // Global variables for audio
-      let audioContext;
-      let audioBuffer;
-      let sourceNode;
-      let analyserNode;
-      let javascriptNode;
-      let audioData = null;
-      let audioPlaying = false;
-      let sampleSize = 1024; // number of samples to collect before analyzing data
-      let amplitudeArray; // array to hold time domain data
-      // This must be hosted on the same server as this page - otherwise you get a Cross Site Scripting error
-      let audioUrl = "viper.mp3";
-      // Global variables for the Graphics
-      let canvasWidth = 512;
-      let canvasHeight = 256;
-      let ctx;
-
-      ctx = document.querySelector("#canvas").getContext("2d");
+      // Useful UI elements
+      const msg = document.querySelector("output");
+      const startBtn = document.querySelector("#start_button");
+      const stopBtn = document.querySelector("#stop_button");
 
       // When the Start button is clicked, finish setting up the audio nodes, play the sound,
       // gather samples for the analysis, update the canvas
-      document.querySelector("#start_button").addEventListener("click", (e) => {
-        // the AudioContext is the primary 'container' for all your audio node objects
-        if (!audioContext) {
-          try {
-            audioContext = new AudioContext();
-          } catch (e) {
-            document.getElementById("msg").textContent("Web Audio API is not supported in this browser");
-          }
-        }
-
+      startBtn.addEventListener("click", (e) => {
         e.preventDefault();
-        // Set up the audio Analyser, the Source Buffer and javascriptNode
-        setupAudioNodes();
-        // setup the event handler that is triggered every time enough samples have been collected
-        // trigger the audio analysis and draw the results
-        javascriptNode.onaudioprocess = () => {
-          // get the Time Domain data for this sample
-          analyserNode.getByteTimeDomainData(amplitudeArray);
-          // draw the display if the audio is playing
-          if (audioPlaying) {
-            requestAnimationFrame(drawTimeDomain);
-          }
-        };
-        // Load the Audio the first time through, otherwise play it from the buffer
-        if (audioData === null) {
-          loadSound(audioUrl);
-        } else {
-          playSound(audioData);
-        }
+        startBtn.disabled = true;
+
+        // A user interaction happened we can create the audioContext
+        const audioContext = new AudioContext();
+      
+        // Load the audio the first time through, otherwise play it from the buffer
+        msg.textContent = "Loading audio…";
+
+        fetch("viper.mp3")
+          .then((response) => response.arrayBuffer())
+          .then((downloadedBuffer) => audioContext.decodeAudioData(downloadedBuffer))
+          .then((decodedBuffer) => {
+            msg.textContent = "Configuring audio stack…";
+
+            // Set up the AudioBufferSourceNode
+            const sourceNode = new AudioBufferSourceNode(audioContext, {
+              buffer: decodedBuffer,
+              loop: true
+            });
+
+            // Set up the audio Analyser and javascriptNode
+            const analyserNode = new AnalyserNode(audioContext);
+            const javascriptNode = audioContext.createScriptProcessor(1024, 1, 1);
+            
+            // Connect the nodes together
+            sourceNode.connect(audioContext.destination);
+            sourceNode.connect(analyserNode);
+            analyserNode.connect(javascriptNode);
+            javascriptNode.connect(audioContext.destination);
+
+            // Play the audio
+            msg.textContent = "Audio playing…";
+            sourceNode.start(0); // Play the sound now
+            let audioPlaying = true;
+
+            // Set up the event handler that is triggered every time enough samples have been collected
+            // then trigger the audio analysis and draw the results
+            javascriptNode.onaudioprocess = () => {
+              // Read the frequency values
+              const amplitudeArray = new Uint8Array(analyserNode.frequencyBinCount);
+
+              // Get the time domain data for this sample
+              analyserNode.getByteTimeDomainData(amplitudeArray);
+
+              // Draw the display when the audio is playing
+              if (audioPlaying) {
+                requestAnimationFrame(() => {
+                  // Draw the time domain in the canvas
+
+                  // Get the canvas 2d context
+                  const canvasContext = document.querySelector("#canvas").getContext("2d");
+
+                  // Define canvas size
+                  const canvasHeight = 512;
+                  const canvasWidth = 256;
+
+                  // Clear the canvas
+                  canvasContext.clearRect(0, 0, canvasHeight, canvasWidth);
+
+                  // Draw the amplitude inside the canvas
+                  for (let i = 0; i < amplitudeArray.length; i++) {
+                    let value = amplitudeArray[i] / 256;
+                    let y = canvasHeight - canvasHeight * value - 1;
+                    canvasContext.fillStyle = "#ffffff";
+                    canvasContext.fillRect(i, y, 1, 1);
+                  }
+                });
+              }
+            };
+
+            // Set up the event handler to stop playing the audio
+            stopBtn.addEventListener("click", (e) => {
+              e.preventDefault();
+              startBtn.disabled = false;
+              stopBtn.disabled = true;
+              sourceNode.stop(0);
+              audioPlaying = false;
+              msg.textContent = "Audio stopped.";
+            });
+            stopBtn.disabled = false;
+          })
+          .catch((e) => {
+            console.error(`Error: ${e}`);
+          });
       });
-
-      // Stop the audio playing
-      document.querySelector("#stop_button").addEventListener("click", (e) => {
-        e.preventDefault();
-        sourceNode.stop(0);
-        audioPlaying = false;
-      });
-
-      function setupAudioNodes() {
-        sourceNode = new AudioBufferSourceNode(audioContext);
-        analyserNode = new AnalyserNode(audioContext);
-        javascriptNode = audioContext.createScriptProcessor(sampleSize, 1, 1);
-        // Create the array for the data values
-        amplitudeArray = new Uint8Array(analyserNode.frequencyBinCount);
-
-        // Now connect the nodes together
-        sourceNode.connect(audioContext.destination);
-        sourceNode.connect(analyserNode);
-        analyserNode.connect(javascriptNode);
-        javascriptNode.connect(audioContext.destination);
-      }
-
-      // Load the audio from the URL via XHR and store it in global variable audioData
-      // Note that the audio load is asynchronous
-      function loadSound(url) {
-        document.getElementById("msg").textContent = "Loading audio...";
-        let request = new XMLHttpRequest();
-        request.open("GET", url, true);
-        request.responseType = "arraybuffer";
-        // When loaded, decode the data and play the sound
-        request.onload =  () => {
-          audioContext.decodeAudioData(
-            request.response,
-            (buffer) => {
-              document.getElementById("msg").textContent =
-                "Audio sample download finished";
-              audioData = buffer;
-              playSound(audioData);
-            },
-            onError
-          );
-        };
-        request.send();
-      }
-
-      // Play the audio and loop until stopped
-      function playSound(buffer) {
-        sourceNode.buffer = buffer;
-        sourceNode.start(0); // Play the sound now
-        sourceNode.loop = true;
-        audioPlaying = true;
-      }
-
-      function onError(e) {
-        console.error(e);
-      }
-
-      function drawTimeDomain() {
-        clearCanvas();
-        for (let i = 0; i < amplitudeArray.length; i++) {
-          let value = amplitudeArray[i] / 256;
-          let y = canvasHeight - canvasHeight * value - 1;
-          ctx.fillStyle = "#ffffff";
-          ctx.fillRect(i, y, 1, 1);
-        }
-      }
-
-      function clearCanvas() {
-        ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-      }
     </script>
   </body>
 </html>

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -81,20 +81,19 @@
 
               // Draw the display when the audio is playing
               if (audioContext.state === "running") {
+                // Draw the time domain in the canvas
                 requestAnimationFrame(() => {
-                  // Draw the time domain in the canvas
-
                   // Get the canvas 2d context
                   const canvasContext = canvasElt.getContext("2d");
 
                   // Clear the canvas
-                  canvasContext.clearRect(0, 0, canvasElt.height, canvasElt.width);
+                  canvasContext.clearRect(0, 0, canvasElt.width, canvasElt.height);
 
                   // Draw the amplitude inside the canvas
                   for (let i = 0; i < amplitudeArray.length; i++) {
-                    let value = amplitudeArray[i] / 256;
-                    let y = canvasElt.height - canvasElt.weight * value - 1;
-                    canvasContext.fillStyle = "#ffffff";
+                    const value = amplitudeArray[i] / 256;
+                    const y = canvasElt.height - canvasElt.height * value;
+                    canvasContext.fillStyle = "white";
                     canvasContext.fillRect(i, y, 1, 1);
                   }
                 });

--- a/audio-analyser/index.html
+++ b/audio-analyser/index.html
@@ -56,7 +56,7 @@
               loop: true
             });
 
-            // Set up the audio Analyser and javascriptNode
+            // Set up the audio analyser and the javascript node
             const analyserNode = new AnalyserNode(audioContext);
             const javascriptNode = audioContext.createScriptProcessor(1024, 1, 1);
             
@@ -69,7 +69,6 @@
             // Play the audio
             msg.textContent = "Audio playing…";
             sourceNode.start(0); // Play the sound now
-            let audioPlaying = true;
 
             // Set up the event handler that is triggered every time enough samples have been collected
             // then trigger the audio analysis and draw the results
@@ -81,7 +80,7 @@
               analyserNode.getByteTimeDomainData(amplitudeArray);
 
               // Draw the display when the audio is playing
-              if (audioPlaying) {
+              if (audioContext.state === "running") {
                 requestAnimationFrame(() => {
                   // Draw the time domain in the canvas
 
@@ -108,7 +107,6 @@
               startBtn.disabled = false;
               stopBtn.disabled = true;
               sourceNode.stop(0);
-              audioPlaying = false;
               msg.textContent = "Audio stopped.";
             });
             stopBtn.disabled = false;


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the audio-analyser example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API and `requestAnimationFrame()` only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix a `</p>` that was autoclosed by transforming it into a `<div>`.
  - Fix the title
- Use `fetch()` instead XHR.
- Lots of cleanups: adding an `<h1>`, minimizing variable declaration at the top, improving messages, disabling widgets that cannot be used at that moment…
 
This doesn't remove `createScriptProcessor` that is deprecated in favor of _audio worklets_; too much work for this PR.

Tested on Firefox, Safari, and Chrome (macOS) via a local server.