### PR TITLE
Update audio-buffer to modern JS

### DIFF
--- a/audio-buffer/index.html
+++ b/audio-buffer/index.html
@@ -32,11 +32,11 @@
       // sample rate of the AudioContext
       const frameCount = audioCtx.sampleRate * 2.0;
 
-      const buffer = audioCtx.createBuffer(
-        channels,
-        frameCount,
-        audioCtx.sampleRate
-      );
+      const buffer = new AudioBuffer(audioCtx, {
+        numberOfChannels: channels,
+        length: frameCount,
+        sampleRate: audioCtx.sampleRate,
+      });
 
       // Fill the buffer with white noise;
       // just random values between -1.0 and 1.0

--- a/audio-buffer/index.html
+++ b/audio-buffer/index.html
@@ -1,79 +1,69 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>AudioBuffer example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <title>Web Audio API: AudioBuffer</title>
   </head>
 
   <body>
-    <h1>AudioBuffer example</h1>
+    <h1>Web Audio API: AudioBuffer</h1>
     <button>Make white noise</button>
-    <pre></pre>
   </body>
-<script>
-const button = document.querySelector('button');
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
+  <script>
+    const button = document.querySelector("button");
 
-pre.innerHTML = myScript.innerHTML;
+    let audioCtx;
 
-let AudioContext = window.AudioContext || window.webkitAudioContext;
-let audioCtx;
+    // Stereo
+    let channels = 2;
 
-// Stereo
-let channels = 2;
+    function init() {
+      audioCtx = new AudioContext();
+    }
 
-function init() {
-  audioCtx = new AudioContext();
-}
+    button.onclick = () => {
+      if (!audioCtx) {
+        init();
+      }
 
+      // Create an empty two second stereo buffer at the
+      // sample rate of the AudioContext
+      const frameCount = audioCtx.sampleRate * 2.0;
 
+      const buffer = audioCtx.createBuffer(
+        channels,
+        frameCount,
+        audioCtx.sampleRate
+      );
 
-button.onclick = function() {
-  if(!audioCtx) {
-    init();
-  }
+      // Fill the buffer with white noise;
+      // just random values between -1.0 and 1.0
+      for (let channel = 0; channel < channels; channel++) {
+        // This gives us the actual array that contains the data
+        const nowBuffering = buffer.getChannelData(channel);
+        for (let i = 0; i < frameCount; i++) {
+          // Math.random() is in [0; 1.0]
+          // audio needs to be in [-1.0; 1.0]
+          nowBuffering[i] = Math.random() * 2 - 1;
+        }
+      }
 
-  // Create an empty two second stereo buffer at the
-  // sample rate of the AudioContext
-  let frameCount = audioCtx.sampleRate * 2.0;
+      // Get an AudioBufferSourceNode.
+      // This is the AudioNode to use when we want to play an AudioBuffer
+      const source = audioCtx.createBufferSource();
+      // Set the buffer in the AudioBufferSourceNode
+      source.buffer = buffer;
+      // Connect the AudioBufferSourceNode to the
+      // destination so we can hear the sound
+      source.connect(audioCtx.destination);
+      // start the source playing
+      source.start();
 
-  let myArrayBuffer = audioCtx.createBuffer(channels, frameCount, audioCtx.sampleRate);
-
-  // Fill the buffer with white noise;
-  //just random values between -1.0 and 1.0
-  for (let channel = 0; channel < channels; channel++) {
-   // This gives us the actual array that contains the data
-   let nowBuffering = myArrayBuffer.getChannelData(channel);
-   for (let i = 0; i < frameCount; i++) {
-     // Math.random() is in [0; 1.0]
-     // audio needs to be in [-1.0; 1.0]
-     nowBuffering[i] = Math.random() * 2 - 1;
-   }
-  }
-
-  // Get an AudioBufferSourceNode.
-  // This is the AudioNode to use when we want to play an AudioBuffer
-  let source = audioCtx.createBufferSource();
-  // set the buffer in the AudioBufferSourceNode
-  source.buffer = myArrayBuffer;
-  // connect the AudioBufferSourceNode to the
-  // destination so we can hear the sound
-  source.connect(audioCtx.destination);
-  // start the source playing
-  source.start();
-
-  source.onended = () => {
-    console.log('White noise finished');
-  }
-}
+      source.onended = () => {
+        console.log("White noise finished.");
+      };
+    };
   </script>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the audio-buffer example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title

I also removed the `innerHTML` that was used to copy the script from the source to the screen: useless, adding complexity, and bad practice.

Tested on Firefox, Safari, and Chrome (macOS) via a local server.