### PR TITLE
Update audiocontext-states to modern JS

### DIFF
--- a/audiocontext-states/index.html
+++ b/audiocontext-states/index.html
@@ -1,110 +1,102 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+  <head lang="en">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>AudioContext states demo</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <title>Web Audio API examples: AudioContext object's states</title>
   </head>
 
   <body>
+    <h1>Web Audio API examples: AudioContext object's states</h1>
 
-  <h1>AudioContext states demo</h1>
+    <button>Create context</button>
+    <button>Suspend context</button>
+    <button>Stop context</button>
 
-  <button>Create context</button>
-  <button>Suspend context</button>
-  <button>Stop context</button>
+    <p>Current context time: No context exists.</p>
 
-  <p>Current context time: No context exists.</p>
+    <script>
+      let audioCtx;
 
+      const startBtn = document.querySelector("button:nth-of-type(1)");
+      const susresBtn = document.querySelector("button:nth-of-type(2)");
+      const stopBtn = document.querySelector("button:nth-of-type(3)");
 
-  <script>
-  let audioCtx;
+      const timeDisplay = document.querySelector("p");
 
-  const startBtn = document.querySelector('button:nth-of-type(1)');
-  const susresBtn = document.querySelector('button:nth-of-type(2)');
-  const stopBtn = document.querySelector('button:nth-of-type(3)');
+      susresBtn.setAttribute("disabled", "disabled");
+      stopBtn.setAttribute("disabled", "disabled");
 
-  const timeDisplay = document.querySelector('p');
+      startBtn.onclick = () => {
+        startBtn.setAttribute("disabled", "disabled");
+        susresBtn.removeAttribute("disabled");
+        stopBtn.removeAttribute("disabled");
 
-  susresBtn.setAttribute('disabled','disabled');
-  stopBtn.setAttribute('disabled','disabled');
+        // Create web audio api context
+        audioCtx = new AudioContext();
 
-  startBtn.onclick = function() {
-    startBtn.setAttribute('disabled','disabled');
-    susresBtn.removeAttribute('disabled');
-    stopBtn.removeAttribute('disabled');
+        // Create an Oscillator and a Gain node
+        const oscillator = audioCtx.createOscillator();
+        const gainNode = audioCtx.createGain();
 
-    // create web audio api context
-    AudioContext = window.AudioContext || window.webkitAudioContext;
-    audioCtx = new AudioContext();
+        // Connect both nodes to the speakers
 
-    // create Oscillator and gain node
-    const oscillator = audioCtx.createOscillator();
-    const gainNode = audioCtx.createGain();
+        oscillator.connect(gainNode);
+        gainNode.connect(audioCtx.destination);
 
-    // connect oscillator to gain node to speakers
+        // Make noise, sweet noise
+        oscillator.type = "square";
+        oscillator.frequency.value = 100; // value in hertz
+        oscillator.start(0);
 
-    oscillator.connect(gainNode);
-    gainNode.connect(audioCtx.destination);
+        gainNode.gain.value = 0.1;
 
-    // Make noise, sweet noise
-    oscillator.type = 'square';
-    oscillator.frequency.value = 100; // value in hertz
-    oscillator.start(0);
+        // Report the state of the audio context to the
+        // console, when it changes
 
-    gainNode.gain.value = 0.1;
+        audioCtx.onstatechange = function () {
+          console.log(audioCtx.state);
+        };
+      };
 
-    // report the state of the audio context to the
-    // console, when it changes
+      // Suspend/resume the audiocontext
+      susresBtn.onclick = () => {
+        if (audioCtx.state === "running") {
+          audioCtx.suspend().then(() => {
+            susresBtn.textContent = "Resume context";
+          });
+        } else if (audioCtx.state === "suspended") {
+          audioCtx.resume().then(() => {
+            susresBtn.textContent = "Suspend context";
+          });
+        }
+      };
 
-    audioCtx.onstatechange = function() {
-      console.log(audioCtx.state);
-    }
-  }
+      // Close the audiocontext
+      stopBtn.onclick = () => {
+        audioCtx.close().then(() => {
+          startBtn.removeAttribute("disabled");
+          susresBtn.setAttribute("disabled", "disabled");
+          // Reset the text of the suspend/resume toggle:
+          susresBtn.textContent = "Suspend context";
+          stopBtn.setAttribute("disabled", "disabled");
+        });
+      };
 
-  // suspend/resume the audiocontext
+      // Helper function
+      function displayTime() {
+        if (audioCtx && audioCtx.state !== "closed") {
+          timeDisplay.textContent = `Current context time: ${audioCtx.currentTime.toFixed(
+            3
+          )}`;
+        } else {
+          timeDisplay.textContent = "Current context time: No context exists.";
+        }
+        requestAnimationFrame(displayTime);
+      }
 
-  susresBtn.onclick = function() {
-    if(audioCtx.state === 'running') {
-      audioCtx.suspend().then(function() {
-        susresBtn.textContent = 'Resume context';
-      });
-    } else if(audioCtx.state === 'suspended') {
-      audioCtx.resume().then(function() {
-        susresBtn.textContent = 'Suspend context';
-      });
-    }
-  }
-
-  // close the audiocontext
-
-  stopBtn.onclick = function() {
-    audioCtx.close().then(function() {
-      startBtn.removeAttribute('disabled');
-      susresBtn.setAttribute('disabled','disabled');
-      stopBtn.setAttribute('disabled','disabled');
-    });
-  }
-
-  function displayTime() {
-    if(audioCtx && audioCtx.state !== 'closed') {
-      timeDisplay.textContent = 'Current context time: ' + audioCtx.currentTime.toFixed(3);
-    } else {
-      timeDisplay.textContent = 'Current context time: No context exists.'
-    }
-    requestAnimationFrame(displayTime);
-  }
-
-  displayTime();
-
-
-  </script>
+      displayTime();
+    </script>
   </body>
 </html>

--- a/audiocontext-states/index.html
+++ b/audiocontext-states/index.html
@@ -37,20 +37,19 @@
         audioCtx = new AudioContext();
 
         // Create an Oscillator and a Gain node
-        const oscillator = audioCtx.createOscillator();
-        const gainNode = audioCtx.createGain();
+        const oscillator = new OscillatorNode(audioCtx, {
+          type: "square",
+          frequency: 100, // Value in Herz
+        });
+        const gainNode = new GainNode(audioCtx, { gain: 0.1 });
 
         // Connect both nodes to the speakers
 
         oscillator.connect(gainNode);
         gainNode.connect(audioCtx.destination);
 
-        // Make noise, sweet noise
-        oscillator.type = "square";
-        oscillator.frequency.value = 100; // value in hertz
+        // Now that everything is connected, starts the sound
         oscillator.start(0);
-
-        gainNode.gain.value = 0.1;
 
         // Report the state of the audio context to the
         // console, when it changes


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the audiocontext-states example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use template literals (string) where possible

In addition:
- Use now the unprefixed version of Web Audio API and `requestAnimationFrame()` only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
 
I also fixed a bug where the label of the toggle button could get out of sync in one case.

Tested on Firefox, Safari, and Chrome (macOS) via a local server.