### PR TITLE
Update compressor-example to modern JS

### DIFF
--- a/compressor-example/index.html
+++ b/compressor-example/index.html
@@ -1,79 +1,68 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>Compressor example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <title>Web Audio API: Compressor example</title>
   </head>
 
   <body>
-    <h1>Compressor example</h1>
+    <h1>Web Audio API: Compressor example</h1>
     <audio controls>
-      <source src="viper.ogg" type="audio/ogg">
-      <source src="viper.mp3" type="audio/mp3">
-      <p>Browser too old to support HTML5 audio? How depressing!</p>
+      <source src="viper.ogg" type="audio/ogg" />
+      <source src="viper.mp3" type="audio/mp3" />
+      <p>This demo needs a browser supporting the &lt;audio&gt; element.</p>
     </audio>
     <button data-active="false">Add compression</button>
-    <pre></pre>
   </body>
-<script>
-const myAudio = document.querySelector('audio');
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-const button = document.querySelector('button');
-let audioCtx;
+  <script>
+    const audioElt = document.querySelector("audio");
+    const pre = document.querySelector("pre");
+    const button = document.querySelector("button");
+    let audioCtx;
 
-pre.innerHTML = myScript.innerHTML;
+    audioElt.addEventListener('play', () => {
+      if (!audioCtx) {
+        // Set up AudioContext
+        audioCtx = new AudioContext();
 
-myAudio.addEventListener('play', () => {
-  if(!audioCtx) {
-    // Set up AudioContext
-    const AudioContext = window.AudioContext || window.webkitAudioContext;
-    audioCtx = new AudioContext();
+        // Create a MediaElementAudioSourceNode
+        // Feed the HTMLMediaElement into it
+        const source = new MediaElementAudioSourceNode(audioCtx, { mediaElement: audioElt });
 
-    // Create a MediaElementAudioSourceNode
-    // Feed the HTMLMediaElement into it
-    const source = audioCtx.createMediaElementSource(myAudio);
-
-    // Create a compressor node
-    const compressor = audioCtx.createDynamicsCompressor();
-    compressor.threshold.value = -50;
-    compressor.knee.value = 40;
-    compressor.ratio.value = 12;
-    compressor.attack.value = 0;
-    compressor.release.value = 0.25;
+        // Create a compressor node
+        const compressor = new DynamicsCompressorNode(audioCtx, {
+          threshold : -50,
+          knee: 40,
+          ratio: 12,
+          attack: 0,
+          release: 0.25
+        });
 
 
-    // connect the AudioBufferSourceNode to the destination
-    source.connect(audioCtx.destination);
-
-    button.onclick = function() {
-      const active = button.getAttribute('data-active');
-      if(active === 'false') {
-        button.setAttribute('data-active', 'true');
-        button.innerHTML = 'Remove compression';
-
-        source.disconnect(audioCtx.destination);
-        source.connect(compressor);
-        compressor.connect(audioCtx.destination);
-      } else if(active === 'true') {
-        button.setAttribute('data-active', 'false');
-        button.innerHTML = 'Add compression';
-
-        source.disconnect(compressor);
-        compressor.disconnect(audioCtx.destination);
+        // connect the AudioBufferSourceNode to the destination
         source.connect(audioCtx.destination);
-      }
-    }
-  }
-})
-  </script>
 
+        button.onclick = () => {
+          const active = button.getAttribute("data-active");
+          if (active === "false") {
+            button.setAttribute("data-active", "true");
+            button.textContent = "Remove compression";
+
+            source.disconnect(audioCtx.destination);
+            source.connect(compressor);
+            compressor.connect(audioCtx.destination);
+          } else if (active === "true") {
+            button.setAttribute("data-active", "false");
+            button.textContent = "Add compression";
+
+            source.disconnect(compressor);
+            compressor.disconnect(audioCtx.destination);
+            source.connect(audioCtx.destination);
+          }
+        }
+      }
+    });
+  </script>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the compressor-example example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
- Removed an unused variable

Tested on Firefox, Safari, and Chrome (macOS) via a local server.