### PR TITLE
Update media-source-buffer to modern JS

### DIFF
--- a/media-source-buffer/index.html
+++ b/media-source-buffer/index.html
@@ -1,66 +1,58 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>createMediaElementSource example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <title>Web Audio API examples: MediaElementAudioSource()</title>
   </head>
 
   <body>
-    <h1>createMediaElementSource example</h1>
+    <h1>Web Audio API examples: MediaElementAudioSource()</h1>
+    <p>Position the cursor vertically to change the volume (down is louder).</p>
     <audio controls>
-      <source src="viper.ogg" type="audio/ogg">
-      <source src="viper.mp3" type="audio/mp3">
-      <p>Browser too old to support HTML5 audio? How depressing!</p>
+      <source src="viper.ogg" type="audio/ogg" />
+      <source src="viper.mp3" type="audio/mp3" />
+      <p>This demo needs a browser supporting the &lt;audio&gt; element.</p>
     </audio>
-    <pre></pre>
   </body>
-<script>
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-let audioCtx;
-const myAudio = document.querySelector('audio');
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
+  <script>
+    let audioCtx;
+    const audioElement = document.querySelector("audio");
 
-pre.innerHTML = myScript.innerHTML;
+    audioElement.addEventListener("play", () => {
+      audioCtx = new AudioContext();
+      // Create a MediaElementAudioSourceNode
+      // Feed the HTMLMediaElement into it
+      let source = new MediaElementAudioSourceNode(audioCtx, { mediaElement: audioElement });
 
-myAudio.addEventListener('play', () => {
-  audioCtx = new AudioContext();
-  // Create a MediaElementAudioSourceNode
-  // Feed the HTMLMediaElement into it
-  let source = audioCtx.createMediaElementSource(myAudio);
+      // Create a gain node
+      let gainNode = new GainNode(audioCtx);
 
-  // Create a gain node
-  let gainNode = audioCtx.createGain();
+      // Create variables to store mouse pointer Y coordinate
+      // and HEIGHT of screen
+      let currentY;
+      let height = window.innerHeight;
 
-  // Create variables to store mouse pointer Y coordinate
-  // and HEIGHT of screen
-  let CurY;
-  let HEIGHT = window.innerHeight;
+      // Get new mouse pointer coordinates when mouse is moved
+      // then set new gain value
 
-  // Get new mouse pointer coordinates when mouse is moved
-  // then set new gain value
+      document.onmousemove = (e) => {
+        currentY = window.Event
+          ? e.pageY
+          : event.clientY +
+            (document.documentElement.scrollTop
+              ? document.documentElement.scrollTop
+              : document.body.scrollTop);
 
-  document.onmousemove = updatePage;
+        gainNode.gain.value = currentY / height;
+      };
 
-  function updatePage(e) {
-    CurY = (window.Event) ? e.pageY : event.clientY + (document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop);
-
-    gainNode.gain.value = CurY/HEIGHT;
-  }
-
-  // connect the AudioBufferSourceNode to the gainNode
-  // and the gainNode to the destination, so we can play the
-  // music and adjust the volume using the mouse cursor
-  source.connect(gainNode);
-  gainNode.connect(audioCtx.destination);
-});
+      // connect the AudioBufferSourceNode to the gainNode
+      // and the gainNode to the destination, so we can play the
+      // music and adjust the volume using the mouse cursor
+      source.connect(gainNode);
+      gainNode.connect(audioCtx.destination);
+    });
   </script>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the media-source-buffer example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
- Rename variables using _my_.
- Added some text explaining how the demo work (not obvious without reading the code)


Tested on Firefox, Safari, and Chrome (macOS) via a local server.