### PR TITLE
Update offline-audio-context to modern JS

### DIFF
--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -19,34 +19,27 @@
     // Define useful DOM nodes as constants
     const play = document.querySelector("#play");
 
-    // Use XHR to load an audio track, and
-    // decodeAudioData to decode it and stick it in a buffer.
-    // Then we put the buffer into the source
+    // Fetch an audio track, decode it and stick it in a buffer.
+    // Then put the buffer into the source and start playing it.
     function getData() {
-      request = new XMLHttpRequest();
-
-      request.open("GET", "viper.ogg", true);
-
-      request.responseType = "arraybuffer";
-
-      request.onload = function () {
-        audioCtx.decodeAudioData(
-          request.response,
-          (decodedBuffer) => {
-            const source = new AudioBufferSourceNode(offlineCtx, {
-              buffer: decodedBuffer,
-            });
-            source.connect(offlineCtx.destination);
-            source.start();
-            offlineCtx.startRendering();
-          },
-          (e) => {
-            console.log(`Error while decoding audio data ${e.err}.`);
-          }
-        );
-      };
-
-      request.send();
+      fetch("viper.ogg")
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => {
+          audioCtx.decodeAudioData(
+            buffer,
+            (decodedBuffer) => {
+              const source = new AudioBufferSourceNode(offlineCtx, {
+                buffer: decodedBuffer,
+              });
+              source.connect(offlineCtx.destination);
+              source.start();
+              offlineCtx.startRendering();
+            },
+            (e) => {
+              console.log(`Error while decoding audio data ${e.err}.`);
+            }
+          );
+        });
     }
 
     // Read the data
@@ -67,7 +60,7 @@
         play.disabled = true;
       };
 
-      console.log("Completed.");
+      console.log("Initialisation completed.");
     };
   </script>
 </html>

--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -1,92 +1,75 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
-    <title>offlineAudioContext example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <title>Web Audio API examples: OfflineAudioContext</title>
   </head>
 
   <body>
-    <h1>offlineAudioContext example</h1>
-
-    <button class="play">Play</button>
-
-    <pre></pre>
+    <h1>Web Audio API examples: OfflineAudioContext</h1>
+    <button id="play" disabled="true">Play</button>
   </body>
-<script>
+  <script>
+    // Define both online and offline audio contexts
+    const audioCtx = new AudioContext();
+    const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
-// define online and offline audio context
+    source = new AudioBufferSourceNode(offlineCtx);
 
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-const audioCtx = new AudioContext();
-const offlineCtx = new OfflineAudioContext(2,44100*40,44100);
+    // Define useful DOM nodes as constants
+    const play = document.querySelector("#play");
 
-source = offlineCtx.createBufferSource();
+    // Use XHR to load an audio track, and
+    // decodeAudioData to decode it and stick it in a buffer.
+    // Then we put the buffer into the source
+    function getData() {
+      request = new XMLHttpRequest();
 
-// define dom node constants
+      request.open("GET", "viper.ogg", true);
 
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-const play = document.querySelector('.play');
-const stop = document.querySelector('.stop');
+      request.responseType = "arraybuffer";
 
-// use XHR to load an audio track, and
-// decodeAudioData to decode it and stick it in a buffer.
-// Then we put the buffer into the source
+      request.onload = function () {
+        let audioData = request.response;
 
-function getData() {
-  request = new XMLHttpRequest();
+        audioCtx.decodeAudioData(
+          audioData,
+          (buffer) => {
+            source.buffer = buffer;
+            source.connect(offlineCtx.destination);
+            source.start();
+            offlineCtx.startRendering();
+          },
+          (e) => {
+            console.log(`Error while decoding audio data ${e.err}.`);
+          }
+        );
+      };
 
-  request.open('GET', 'viper.ogg', true);
+      request.send();
+    }
 
-  request.responseType = 'arraybuffer';
+    // Read the data
+    getData();
 
+    // Once the data is ready, let's start the song.
+    offlineCtx.oncomplete = (e) => {
+      const song = new AudioBufferSourceNode(audioCtx, {
+        buffer: e.renderedBuffer,
+      });
+      song.connect(audioCtx.destination);
 
-  request.onload = function() {
-    let audioData = request.response;
+      // Loaded and connected, we can play it we want
+      play.disabled = false;
+      play.onclick = () => {
+        song.start();
+        // No rerun possible as we can't start() it again.
+        play.disabled = true;
+      };
 
-    audioCtx.decodeAudioData(audioData, function(buffer) {
-        myBuffer = buffer;
-        source.buffer = myBuffer;
-        source.connect(offlineCtx.destination);
-        source.start();
-        //source.loop = true;
-        offlineCtx.startRendering();
-      },
-
-      function(e){"Error with decoding audio data" + e.err});
-
-  }
-
-  request.send();
-}
-
-// wire up buttons to stop and play audio, and range slider control
-
-getData();
-
-offlineCtx.oncomplete = function(e) {
-  let song = audioCtx.createBufferSource();
-  song.buffer = e.renderedBuffer;
-
-  song.connect(audioCtx.destination);
-
-  play.onclick = function() {
-    song.start();
-  }
-
-  console.log("completed!");
-}
-
-// dump script to pre element
-
-pre.innerHTML = myScript.innerHTML;
+      console.log("Completed.");
+    };
   </script>
 </html>

--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -9,11 +9,11 @@
 
   <body>
     <h1>Web Audio API examples: OfflineAudioContext</h1>
-    <button id="play" disabled="true">Play</button>
+    <button id="play">Play</button>
   </body>
   <script>
     // Define both online and offline audio contexts
-    const audioCtx = new AudioContext();
+    let audioCtx; // Must be defined after a user action
     const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
     // Define useful DOM nodes as constants
@@ -42,25 +42,27 @@
         });
     }
 
-    // Read the data
-    getData();
-
     // Once the data is ready, let's start the song.
     offlineCtx.oncomplete = (e) => {
       const song = new AudioBufferSourceNode(audioCtx, {
         buffer: e.renderedBuffer,
       });
       song.connect(audioCtx.destination);
+      
+      // Play the song
+      song.start();
+    };
 
-      // Loaded and connected, we can play it we want
-      play.disabled = false;
-      play.onclick = () => {
-        song.start();
-        // No rerun possible as we can't start() it again.
-        play.disabled = true;
-      };
+    play.onclick = () => {
+      // The user did an action, we can create an audio context
+      audioCtx = new AudioContext();
 
+      // Read the data
+      getData();
       console.log("Initialisation completed.");
+
+      // No rerun possible as we can't call start() it again.
+      play.disabled = true;
     };
   </script>
 </html>

--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -16,8 +16,6 @@
     const audioCtx = new AudioContext();
     const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
-    source = new AudioBufferSourceNode(offlineCtx);
-
     // Define useful DOM nodes as constants
     const play = document.querySelector("#play");
 
@@ -32,12 +30,12 @@
       request.responseType = "arraybuffer";
 
       request.onload = function () {
-        let audioData = request.response;
-
         audioCtx.decodeAudioData(
-          audioData,
-          (buffer) => {
-            source.buffer = buffer;
+          request.response,
+          (decodedBuffer) => {
+            const source = new AudioBufferSourceNode(offlineCtx, {
+              buffer: decodedBuffer,
+            });
             source.connect(offlineCtx.destination);
             source.start();
             offlineCtx.startRendering();


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the offline-audio-context example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
- Remove unused variables
- Replace XHR by `fetch()`

Tested on Firefox, Safari, and Chrome (macOS) via a local server.