### PR TITLE
Update offline-audio-context-promise to modern JS

### DIFF
--- a/offline-audio-context-promise/index.html
+++ b/offline-audio-context-promise/index.html
@@ -8,65 +8,55 @@
 
   <body>
     <h1>Web Audio API examples: OfflineAudioContext (using promises)</h1>
-    <button id="play" disabled="true">Play</button>
+    <button id="play">Play</button>
   </body>
   <script>
     // Define both online and offline audio contexts
-    const audioCtx = new AudioContext();
+    let audioCtx; // Must be initialized after a user interaction
     const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
     // Define constants for dom nodes
     const play = document.querySelector("#play");
 
-    // use XHR to load an audio track, and
-    // decodeAudioData to decode it and stick it in a buffer.
-    // Then we put the buffer into the source
-
     function getData() {
-      request = new XMLHttpRequest();
-
-      request.open("GET", "viper.ogg", true);
-
-      request.responseType = "arraybuffer";
-
-      request.onload = () => {
-        audioCtx.decodeAudioData(request.response).then((downloadedBuffer) => {
+      // Fetch an audio track, decode it and stick it in a buffer.
+      // Then we put the buffer into the source and can play it.
+      fetch("viper.ogg")
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => audioCtx.decodeAudioData(buffer))
+        .then((downloadedBuffer) => {
           console.log("File downloaded.successfully.");
           const source = new AudioBufferSourceNode(offlineCtx, {
             buffer: downloadedBuffer,
           });
           source.connect(offlineCtx.destination);
-          source.start();
-
-          offlineCtx
-            .startRendering()
-            .then((renderedBuffer) => {
-              console.log("Rendering completed successfully.");
-              play.disabled = false;
-              const song = new AudioBufferSourceNode(audioCtx, {
-                buffer: renderedBuffer,
-              });
-              song.connect(audioCtx.destination);
-
-              play.onclick = () => {
-                song.start();
-                play.disabled = true;
-              };
-            })
-            .catch((err) => {
-              console.error(`Rendering failed: ${err}`);
-            });
+          return source.start();
+        })
+        .then(() => offlineCtx.startRendering())
+        .then((renderedBuffer) => {
+          console.log("Rendering completed successfully.");
+          play.disabled = false;
+          const song = new AudioBufferSourceNode(audioCtx, {
+            buffer: renderedBuffer,
+          });
+          song.connect(audioCtx.destination);
+          
+          // Start the song
+          song.start();
         })
         .catch((err) => {
-          console.error(`Download error: ${err}`);
+          console.error(`Error encountered: ${err}`);
         });
-      };
-
-      request.send();
     }
 
-    // Run getData to start the process off
+    // Activate the play button 
+    play.onclick = () => {
+      play.disabled = true;
+      // We can initialize the context as the user clicked.
+      audioCtx = new AudioContext();
 
-    getData();
+      // Fetch the data and start the song
+      getData();
+    };
   </script>
 </html>

--- a/offline-audio-context-promise/index.html
+++ b/offline-audio-context-promise/index.html
@@ -9,54 +9,56 @@
   <body>
     <h1>Web Audio API examples: OfflineAudioContext (using promises)</h1>
     <button id="play">Play</button>
+    <script>
+      // Define both online and offline audio contexts
+      let audioCtx; // Must be initialized after a user interaction
+      const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
+
+      // Define constants for dom nodes
+      const play = document.querySelector("#play");
+
+      function getData() {
+        // Fetch an audio track, decode it and stick it in a buffer.
+        // Then we put the buffer into the source and can play it.
+        fetch("viper.ogg")
+          .then((response) => response.arrayBuffer())
+          .then((downloadedBuffer) =>
+            audioCtx.decodeAudioData(downloadedBuffer)
+          )
+          .then((decodedBuffer) => {
+            console.log("File downloaded.successfully.");
+            const source = new AudioBufferSourceNode(offlineCtx, {
+              buffer: decodedBuffer,
+            });
+            source.connect(offlineCtx.destination);
+            return source.start();
+          })
+          .then(() => offlineCtx.startRendering())
+          .then((renderedBuffer) => {
+            console.log("Rendering completed successfully.");
+            play.disabled = false;
+            const song = new AudioBufferSourceNode(audioCtx, {
+              buffer: renderedBuffer,
+            });
+            song.connect(audioCtx.destination);
+
+            // Start the song
+            song.start();
+          })
+          .catch((err) => {
+            console.error(`Error encountered: ${err}`);
+          });
+      }
+
+      // Activate the play button
+      play.onclick = () => {
+        play.disabled = true;
+        // We can initialize the context as the user clicked.
+        audioCtx = new AudioContext();
+
+        // Fetch the data and start the song
+        getData();
+      };
+    </script>
   </body>
-  <script>
-    // Define both online and offline audio contexts
-    let audioCtx; // Must be initialized after a user interaction
-    const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
-
-    // Define constants for dom nodes
-    const play = document.querySelector("#play");
-
-    function getData() {
-      // Fetch an audio track, decode it and stick it in a buffer.
-      // Then we put the buffer into the source and can play it.
-      fetch("viper.ogg")
-        .then((response) => response.arrayBuffer())
-        .then((downloadedBuffer) => audioCtx.decodeAudioData(downloadedBuffer))
-        .then((decodedBuffer) => {
-          console.log("File downloaded.successfully.");
-          const source = new AudioBufferSourceNode(offlineCtx, {
-            buffer: decodedBuffer,
-          });
-          source.connect(offlineCtx.destination);
-          return source.start();
-        })
-        .then(() => offlineCtx.startRendering())
-        .then((renderedBuffer) => {
-          console.log("Rendering completed successfully.");
-          play.disabled = false;
-          const song = new AudioBufferSourceNode(audioCtx, {
-            buffer: renderedBuffer,
-          });
-          song.connect(audioCtx.destination);
-          
-          // Start the song
-          song.start();
-        })
-        .catch((err) => {
-          console.error(`Error encountered: ${err}`);
-        });
-    }
-
-    // Activate the play button 
-    play.onclick = () => {
-      play.disabled = true;
-      // We can initialize the context as the user clicked.
-      audioCtx = new AudioContext();
-
-      // Fetch the data and start the song
-      getData();
-    };
-  </script>
 </html>

--- a/offline-audio-context-promise/index.html
+++ b/offline-audio-context-promise/index.html
@@ -23,11 +23,11 @@
       // Then we put the buffer into the source and can play it.
       fetch("viper.ogg")
         .then((response) => response.arrayBuffer())
-        .then((buffer) => audioCtx.decodeAudioData(buffer))
-        .then((downloadedBuffer) => {
+        .then((downloadedBuffer) => audioCtx.decodeAudioData(downloadedBuffer))
+        .then((decodedBuffer) => {
           console.log("File downloaded.successfully.");
           const source = new AudioBufferSourceNode(offlineCtx, {
-            buffer: downloadedBuffer,
+            buffer: decodedBuffer,
           });
           source.connect(offlineCtx.destination);
           return source.start();

--- a/offline-audio-context-promise/index.html
+++ b/offline-audio-context-promise/index.html
@@ -1,89 +1,72 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>offlineAudioContext example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
     <h1>offlineAudioContext example with startRendering() promise</h1>
-
-    <button class="play">Play</button>
-
-    <pre></pre>
+    <button id="play" disabled="true">Play</button>
   </body>
-<script>
+  <script>
+    // Define both online and offline audio contexts
+    const audioCtx = new AudioContext();
+    const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
-// define online and offline audio context
+    // Define constants for dom nodes
+    const play = document.querySelector("#play");
 
-let audioCtx = new AudioContext();
-let offlineCtx = new OfflineAudioContext(2,44100*40,44100);
+    // use XHR to load an audio track, and
+    // decodeAudioData to decode it and stick it in a buffer.
+    // Then we put the buffer into the source
 
-source = offlineCtx.createBufferSource();
+    function getData() {
+      request = new XMLHttpRequest();
 
-// define constants for dom nodes
+      request.open("GET", "viper.ogg", true);
 
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-const play = document.querySelector('.play');
-const stop = document.querySelector('.stop');
+      request.responseType = "arraybuffer";
 
-// use XHR to load an audio track, and
-// decodeAudioData to decode it and stick it in a buffer.
-// Then we put the buffer into the source
+      request.onload = () => {
+        audioCtx.decodeAudioData(request.response).then((downloadedBuffer) => {
+          console.log("File downloaded.successfully.");
+          const source = new AudioBufferSourceNode(offlineCtx, {
+            buffer: downloadedBuffer,
+          });
+          source.connect(offlineCtx.destination);
+          source.start();
 
-function getData() {
-  request = new XMLHttpRequest();
+          offlineCtx
+            .startRendering()
+            .then((renderedBuffer) => {
+              console.log("Rendering completed successfully.");
+              play.disabled = false;
+              const song = new AudioBufferSourceNode(audioCtx, {
+                buffer: renderedBuffer,
+              });
+              song.connect(audioCtx.destination);
 
-  request.open('GET', 'viper.ogg', true);
+              play.onclick = () => {
+                song.start();
+                play.disabled = true;
+              };
+            })
+            .catch((err) => {
+              console.error(`Rendering failed: ${err}`);
+            });
+        })
+        .catch((err) => {
+          console.error(`Download error: ${err}`);
+        });
+      };
 
-  request.responseType = 'arraybuffer';
+      request.send();
+    }
 
+    // Run getData to start the process off
 
-  request.onload = function() {
-    let audioData = request.response;
-
-    audioCtx.decodeAudioData(audioData, function(buffer) {
-      myBuffer = buffer;
-      source.buffer = myBuffer;
-      source.connect(offlineCtx.destination);
-      source.start();
-      //source.loop = true;
-      offlineCtx.startRendering().then(function(renderedBuffer) {
-        console.log('Rendering completed successfully');
-        
-        let song = audioCtx.createBufferSource();
-        song.buffer = renderedBuffer;
-
-        song.connect(audioCtx.destination);
-
-        play.onclick = function() {
-          song.start();
-        }
-      }).catch(function(err) {
-          console.log('Rendering failed: ' + err);
-          // Note: The promise should reject when startRendering is called a second time on an OfflineAudioContext
-      });
-    });
-  }
-
-  request.send();
-}
-
-// Run getData to start the process off
-
-getData();
-
-// dump script to pre element
-
-pre.innerHTML = myScript.innerHTML;
+    getData();
   </script>
 </html>

--- a/offline-audio-context-promise/index.html
+++ b/offline-audio-context-promise/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <title>offlineAudioContext example</title>
+    <title>Web Audio API examples: OfflineAudioContext (using promises)</title>
   </head>
 
   <body>
-    <h1>offlineAudioContext example with startRendering() promise</h1>
+    <h1>Web Audio API examples: OfflineAudioContext (using promises)</h1>
     <button id="play" disabled="true">Play</button>
   </body>
   <script>

--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width" />
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width">
 
     <title>offlineAudioContext example</title>
 
-    <link rel="stylesheet" href="" />
+    <link rel="stylesheet" href="">
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -20,75 +20,73 @@
 
     <pre></pre>
   </body>
-  <script>
-    // define online and offline audio context
+<script>
 
-    const AudioContext = window.AudioContext || window.webkitAudioContext;
-    const audioCtx = new AudioContext();
-    const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
+// define online and offline audio context
 
-    source = offlineCtx.createBufferSource();
+const AudioContext = window.AudioContext || window.webkitAudioContext;
+const audioCtx = new AudioContext();
+const offlineCtx = new OfflineAudioContext(2,44100*40,44100);
 
-    // define dom node constants
+source = offlineCtx.createBufferSource();
 
-    const pre = document.querySelector("pre");
-    const myScript = document.querySelector("script");
-    const play = document.querySelector(".play");
-    const stop = document.querySelector(".stop");
+// define dom node constants
 
-    // use XHR to load an audio track, and
-    // decodeAudioData to decode it and stick it in a buffer.
-    // Then we put the buffer into the source
+const pre = document.querySelector('pre');
+const myScript = document.querySelector('script');
+const play = document.querySelector('.play');
+const stop = document.querySelector('.stop');
 
-    function getData() {
-      request = new XMLHttpRequest();
+// use XHR to load an audio track, and
+// decodeAudioData to decode it and stick it in a buffer.
+// Then we put the buffer into the source
 
-      request.open("GET", "viper.ogg", true);
+function getData() {
+  request = new XMLHttpRequest();
 
-      request.responseType = "arraybuffer";
+  request.open('GET', 'viper.ogg', true);
 
-      request.onload = function () {
-        let audioData = request.response;
+  request.responseType = 'arraybuffer';
 
-        audioCtx.decodeAudioData(
-          audioData,
-          function (buffer) {
-            myBuffer = buffer;
-            source.buffer = myBuffer;
-            source.connect(offlineCtx.destination);
-            source.start();
-            //source.loop = true;
-            offlineCtx.startRendering();
-          },
 
-          function (e) {
-            "Error with decoding audio data" + e.err;
-          }
-        );
-      };
+  request.onload = function() {
+    let audioData = request.response;
 
-      request.send();
-    }
+    audioCtx.decodeAudioData(audioData, function(buffer) {
+        myBuffer = buffer;
+        source.buffer = myBuffer;
+        source.connect(offlineCtx.destination);
+        source.start();
+        //source.loop = true;
+        offlineCtx.startRendering();
+      },
 
-    // wire up buttons to stop and play audio, and range slider control
+      function(e){"Error with decoding audio data" + e.err});
 
-    getData();
+  }
 
-    offlineCtx.oncomplete = function (e) {
-      let song = audioCtx.createBufferSource();
-      song.buffer = e.renderedBuffer;
+  request.send();
+}
 
-      song.connect(audioCtx.destination);
+// wire up buttons to stop and play audio, and range slider control
 
-      play.onclick = function () {
-        song.start();
-      };
+getData();
 
-      console.log("completed!");
-    };
+offlineCtx.oncomplete = function(e) {
+  let song = audioCtx.createBufferSource();
+  song.buffer = e.renderedBuffer;
 
-    // dump script to pre element
+  song.connect(audioCtx.destination);
 
-    pre.innerHTML = myScript.innerHTML;
+  play.onclick = function() {
+    song.start();
+  }
+
+  console.log("completed!");
+}
+
+// dump script to pre element
+
+pre.innerHTML = myScript.innerHTML;
   </script>
 </html>

--- a/offline-audio-context/index.html
+++ b/offline-audio-context/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width" />
 
     <title>offlineAudioContext example</title>
 
-    <link rel="stylesheet" href="">
+    <link rel="stylesheet" href="" />
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -20,73 +20,75 @@
 
     <pre></pre>
   </body>
-<script>
+  <script>
+    // define online and offline audio context
 
-// define online and offline audio context
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = new AudioContext();
+    const offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-const audioCtx = new AudioContext();
-const offlineCtx = new OfflineAudioContext(2,44100*40,44100);
+    source = offlineCtx.createBufferSource();
 
-source = offlineCtx.createBufferSource();
+    // define dom node constants
 
-// define dom node constants
+    const pre = document.querySelector("pre");
+    const myScript = document.querySelector("script");
+    const play = document.querySelector(".play");
+    const stop = document.querySelector(".stop");
 
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-const play = document.querySelector('.play');
-const stop = document.querySelector('.stop');
+    // use XHR to load an audio track, and
+    // decodeAudioData to decode it and stick it in a buffer.
+    // Then we put the buffer into the source
 
-// use XHR to load an audio track, and
-// decodeAudioData to decode it and stick it in a buffer.
-// Then we put the buffer into the source
+    function getData() {
+      request = new XMLHttpRequest();
 
-function getData() {
-  request = new XMLHttpRequest();
+      request.open("GET", "viper.ogg", true);
 
-  request.open('GET', 'viper.ogg', true);
+      request.responseType = "arraybuffer";
 
-  request.responseType = 'arraybuffer';
+      request.onload = function () {
+        let audioData = request.response;
 
+        audioCtx.decodeAudioData(
+          audioData,
+          function (buffer) {
+            myBuffer = buffer;
+            source.buffer = myBuffer;
+            source.connect(offlineCtx.destination);
+            source.start();
+            //source.loop = true;
+            offlineCtx.startRendering();
+          },
 
-  request.onload = function() {
-    let audioData = request.response;
+          function (e) {
+            "Error with decoding audio data" + e.err;
+          }
+        );
+      };
 
-    audioCtx.decodeAudioData(audioData, function(buffer) {
-        myBuffer = buffer;
-        source.buffer = myBuffer;
-        source.connect(offlineCtx.destination);
-        source.start();
-        //source.loop = true;
-        offlineCtx.startRendering();
-      },
+      request.send();
+    }
 
-      function(e){"Error with decoding audio data" + e.err});
+    // wire up buttons to stop and play audio, and range slider control
 
-  }
+    getData();
 
-  request.send();
-}
+    offlineCtx.oncomplete = function (e) {
+      let song = audioCtx.createBufferSource();
+      song.buffer = e.renderedBuffer;
 
-// wire up buttons to stop and play audio, and range slider control
+      song.connect(audioCtx.destination);
 
-getData();
+      play.onclick = function () {
+        song.start();
+      };
 
-offlineCtx.oncomplete = function(e) {
-  let song = audioCtx.createBufferSource();
-  song.buffer = e.renderedBuffer;
+      console.log("completed!");
+    };
 
-  song.connect(audioCtx.destination);
+    // dump script to pre element
 
-  play.onclick = function() {
-    song.start();
-  }
-
-  console.log("completed!");
-}
-
-// dump script to pre element
-
-pre.innerHTML = myScript.innerHTML;
+    pre.innerHTML = myScript.innerHTML;
   </script>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the offline-audio-context-promise example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use literal string where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
- Use promise versions of API if possible.
- Migrate XHR to `fetch()`
- Make sure the `AudioContext` ctor is called after user interaction.

Tested on Firefox, Safari, and Chrome (macOS) via a local server.