### PR TITLE
Update output-timestamp to modern JS

### DIFF
--- a/output-timestamp/index.html
+++ b/output-timestamp/index.html
@@ -1,85 +1,74 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-    <title>Output timestamp example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Web Audio API examples: Output timestamp</title>
   </head>
 
   <body>
-    <h1>Output timestamp example</h1>
-    <button class="play">Play</button>
-    <button class="stop">Stop</button>
-    <pre></pre>
+    <h1>Web Audio API examples: Output timestamp</h1>
+    <button id="play">Play</button>
+    <button id="stop" disabled="true">Stop</button>
+    <output />
   </body>
-<script>
+  <script>
+    // Define global variables
+    let audioCtx; // It can *only* be created after a user action.
+    let source; // We need the audio context to create it
+    let rAF; // Id of the current requestAnimationFrame() to remove it
 
+    // UI elements that we want to access
+    const playBtn = document.querySelector("#play");
+    const stopBtn = document.querySelector("#stop");
+    const output = document.querySelector("output");
 
-// define variables
+    // Fetch the audio track, then decode it into a buffer.
+    // Finally, use this buffer as the source of audio.
+    function getData() {
+      console.log("Fetch the audio file…");
+      fetch("outfoxing.mp3")
+        .then((response) => response.arrayBuffer())
+        .then((downloadedBuffer) => audioCtx.decodeAudioData(downloadedBuffer))
+        .then((decodedBuffer) => {
+          source.buffer = decodedBuffer;
+          source.connect(audioCtx.destination);
+          source.loop = true;
+          playBtn.disabled = true; // We are ready.
+          console.log("Audio ready.");
+        })
+        .catch((e) => {
+          console.error(`Error while reading the audio data: ${e.error}`);
+        });
+    }
 
-let audioCtx;
-let source;
-let songLength;
-let rAF;
-
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-const play = document.querySelector('.play');
-const stop = document.querySelector('.stop');
-
-// use XHR to load an audio track, and
-// decodeAudioData to decode it and stick it in a buffer.
-// Then we put the buffer into the source
-
-function getData() {
-  source = audioCtx.createBufferSource();
-  fetch('outfoxing.mp3')
-  .then(response => response.arrayBuffer())
-  .then(buffer => {
-    let audioData = buffer;
-    audioCtx.decodeAudioData(audioData, function(buffer) {
-      myBuffer = buffer;
-      songLength = buffer.duration;
-      source.buffer = myBuffer;
-      source.connect(audioCtx.destination);
-      source.loop = true;
-    },
-    function(e) {
-      "Error with decoding audio data" + e.error
+    // Press the play button
+    playBtn.addEventListener("click", () => {
+      // We can create the audioCtx as there has been some user action
+      if (!audioCtx) {
+        audioCtx = new AudioContext();
+      }
+      source = new AudioBufferSourceNode(audioCtx); 
+      getData();
+      source.start(0);
+      playBtn.disabled = true;
+      stopBtn.disabled = false;
+      rAF = requestAnimationFrame(outputTimestamps);
     });
-  })
-}
 
-// wire up buttons to stop and play audio, and range slider control
+    // Press the stop button
+    stopBtn.addEventListener("click", () => {
+      source.stop(0);
+      playBtn.disabled = false;
+      stopBtn.disabled = true;
+      cancelAnimationFrame(rAF);
+    });
 
-play.addEventListener('click', () => {
-  if(!audioCtx) {
-    audioCtx = new window.AudioContext();
-  }
-
-  getData();
-  source.start(0);
-  play.setAttribute('disabled', 'disabled');
-
-  rAF = requestAnimationFrame(outputTimestamps);
-});
-
-stop.addEventListener('click', () => {
-  source.stop(0);
-  play.removeAttribute('disabled');
-  cancelAnimationFrame(rAF);
-});
-
-// function to output timestamps
-
-function outputTimestamps() {
-  let ts = audioCtx.getOutputTimestamp()
-  console.log('Context time: ' + ts.contextTime + ' | Performance time: ' + ts.performanceTime);
-  rAF = requestAnimationFrame(outputTimestamps);
-}
-
-// dump script to pre element
-pre.innerHTML = myScript.innerHTML;
+    // Helper function to output timestamps
+    function outputTimestamps() {
+      const ts = audioCtx.getOutputTimestamp();
+      output.textContent = `Context time: ${ts.contextTime} | Performance time: ${ts.performanceTime}`;
+      rAF = requestAnimationFrame(outputTimestamps); // Reregister itself
+    }
   </script>
 </html>

--- a/output-timestamp/index.html
+++ b/output-timestamp/index.html
@@ -10,7 +10,7 @@
     <h1>Web Audio API examples: Output timestamp</h1>
     <button id="play">Play</button>
     <button id="stop" disabled="true">Stop</button>
-    <output />
+    <output><output/>
   </body>
   <script>
     // Define global variables


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the output-timestamp example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use literal string where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
- Use promise versions of API if possible.
- Fixed the buttons to work as expected.

Tested on Firefox, Safari, and Chrome (macOS) via a local server.