### PR TITLE
Update panner mode to modern JS

### DIFF
--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
 
     <title>Room of metal</title>
 
-    <link href='https://fonts.googleapis.com/css?family=UnifrakturMaguntia' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="style.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=UnifrakturMaguntia"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link rel="stylesheet" href="style.css" />
   </head>
 
   <body>
@@ -18,7 +22,6 @@
 
     <p class="listener-data">Listener data:</p>
     <p class="panner-data">Panner data:</p>
-
 
     <section class="room">
       <div class="flex-wrapper">
@@ -32,10 +35,30 @@
       <button class="move right"></button>
     </section>
 
-    <p><strong>Instructions:</strong> After pressing Play, use the left, right, zoom in and zoom out buttons to control your positionrelative to the boom box.</p>
-    <p><em>Run this on a computer with stereo sound to see how this affects the sound spatialisation.</em></p> 
+    <p>
+      <strong>Instructions:</strong> After pressing Play, use the left, right,
+      zoom in and zoom out buttons to control your positionrelative to the boom
+      box.
+    </p>
+    <p>
+      <em
+        >Run this on a computer with stereo sound to see how this affects the
+        sound spatialisation.</em
+      >
+    </p>
 
-    <p>Boom box icons courtesy of <a href="http://www.flaticon.com/free-icon/boom-box-with-controls-and-settings_26643">flatiron.com</a>, and created by <a href="http://www.flaticon.com/authors/freepik">Freepik</a>, <a href="http://www.flaticon.com/authors/appzgear">Appzgear</a> and <a href="http://www.flaticon.com/authors/adam-whitcroft">Adam Whitcroft</a></p>
+    <p>
+      Boom box icons courtesy of
+      <a
+        href="http://www.flaticon.com/free-icon/boom-box-with-controls-and-settings_26643"
+        >flatiron.com</a
+      >, and created by
+      <a href="http://www.flaticon.com/authors/freepik">Freepik</a>,
+      <a href="http://www.flaticon.com/authors/appzgear">Appzgear</a> and
+      <a href="http://www.flaticon.com/authors/adam-whitcroft"
+        >Adam Whitcroft</a
+      >
+    </p>
   </body>
-<script src="main.js"></script>
+  <script src="main.js"></script>
 </html>

--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -38,7 +38,7 @@
 
     <p>
       <strong>Instructions:</strong> After pressing Play, use the left, right,
-      zoom in and zoom out buttons to control your positionrelative to the boom
+      zoom in and zoom out buttons to control your position relative to the boom
       box.
     </p>
     <p>

--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -1,17 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
 
     <title>Room of metal</title>
 
-    <link href='http://fonts.googleapis.com/css?family=UnifrakturMaguntia' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=UnifrakturMaguntia' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="style.css">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -36,7 +32,8 @@
       <button class="move right"></button>
     </section>
 
-    <p>After pressing Play, use the left, right, zoom in and zoom out buttons to control your position; run this on a computer with stereo sound to see how this affects the sound spatialisation.</p> 
+    <p><strong>Instructions:</strong> After pressing Play, use the left, right, zoom in and zoom out buttons to control your positionrelative to the boom box.</p>
+    <p><em>Run this on a computer with stereo sound to see how this affects the sound spatialisation.</em></p> 
 
     <p>Boom box icons courtesy of <a href="http://www.flaticon.com/free-icon/boom-box-with-controls-and-settings_26643">flatiron.com</a>, and created by <a href="http://www.flaticon.com/authors/freepik">Freepik</a>, <a href="http://www.flaticon.com/authors/appzgear">Appzgear</a> and <a href="http://www.flaticon.com/authors/adam-whitcroft">Adam Whitcroft</a></p>
   </body>

--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -12,6 +12,7 @@
       type="text/css"
     />
     <link rel="stylesheet" href="style.css" />
+    <script src="main.js"></script>
   </head>
 
   <body>
@@ -60,5 +61,4 @@
       >
     </p>
   </body>
-  <script src="main.js"></script>
 </html>

--- a/panner-node/main.js
+++ b/panner-node/main.js
@@ -8,8 +8,8 @@ let zPos = 295;
 
 // play, stop, and other important dom nodes
 
-const play = document.querySelector('.play');
-const stop = document.querySelector('.stop');
+const playBtn = document.querySelector('.play');
+const stopBtn = document.querySelector('.stop');
 const boomBox = document.querySelector('.boom-box');
 const listenerData = document.querySelector('.listener-data');
 const pannerData = document.querySelector('.panner-data');
@@ -26,45 +26,43 @@ let boomX = 0;
 let boomY = 0;
 let boomZoom = 0.50;
 
-// variables to hold information that needs to be assigned upon play
-
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-let audioCtx;
+// Variables to hold information that needs to be assigned upon play
+// Audio context must be created only after the user has interacted.
+let audioCtx; 
 let panner;
 let listener;
 let source;
 
 function init() {
   audioCtx = new AudioContext();
-  panner = audioCtx.createPanner();
   listener = audioCtx.listener;
+  console.log(listener);
 
-  panner.panningModel = 'HRTF';
-  panner.distanceModel = 'inverse';
-  panner.refDistance = 1;
-  panner.maxDistance = 10000;
-  panner.rolloffFactor = 1;
-  panner.coneInnerAngle = 360;
-  panner.coneOuterAngle = 0;
-  panner.coneOuterGain = 0;
+  panner = new PannerNode(audioCtx, {
+    panningModel: 'HRTF',
+    distanceModel: 'inverse',
+    refDistance: 1,
+    maxDistance: 10000,
+    rolloffFactor: 1,
+    coneInnerAngle: 360,
+    coneOuterAngle: 0,
+    coneOuterGain: 0,
+    orientationX: 1,
+    orientationY: 0,
+    orientationZ: 0
+  });
 
-  if(panner.orientationX) {
-    panner.orientationX.value = 1;
-    panner.orientationY.value = 0;
-    panner.orientationZ.value = 0;
+  if (!listener.forwardX) {
+    // Deprecated but still needed (July 2022)
+    listener.setOrientation(0, 0, -1, 0, 1, 0);
   } else {
-    panner.setOrientation(1,0,0);
-  }
-
-  if(listener.forwardX) {
+    // Standard way
     listener.forwardX.value = 0;
     listener.forwardY.value = 0;
     listener.forwardZ.value = -1;
     listener.upX.value = 0;
     listener.upY.value = 1;
     listener.upZ.value = 0;
-  } else {
-    listener.setOrientation(0,0,-1,0,1,0);
   }
 
   leftBound = (-xPos) + 50;
@@ -74,69 +72,53 @@ function init() {
 
   // listener will always be in the same place for this demo
 
-  if(listener.positionX) {
+  if (!listener.positionX) {
+    // Deprecated but still needed (July 2022)
+    listener.setPosition(xPos, yPos, 300);
+  } else {
+    // Standard way
     listener.positionX.value = xPos;
     listener.positionY.value = yPos;
     listener.positionZ.value = 300;
-  } else {
-    listener.setPosition(xPos,yPos,300);
   }
 
-  listenerData.innerHTML = 'Listener data: X ' + xPos + ' Y ' + yPos + ' Z ' + 300;
+  listenerData.textContent = `Listener data: X ${xPos} Y ${yPos} Z ${300}`;
 
   // panner will move as the boombox graphic moves around on the screen
   function positionPanner() {
-    if(panner.positionX) {
-      panner.positionX.value = xPos;
-      panner.positionY.value = yPos;
-      panner.positionZ.value = zPos;
-    } else {
-      panner.setPosition(xPos,yPos,zPos);
-    }
-    pannerData.innerHTML = 'Panner data: X ' + xPos + ' Y ' + yPos + ' Z ' + zPos;
+    panner.positionX.value = xPos;
+    panner.positionY.value = yPos;
+    panner.positionZ.value = zPos;
+    pannerData.textContent = `Panner data: X ${xPos} Y ${yPos} Z ${300}`;
   }
 
-
-  // use XHR to load an audio track, and
-  // decodeAudioData to decode it and stick it in a buffer.
+  // Fetch an audio track, decode it and stick it in a buffer.
   // Then we put the buffer into the source
-
   function getData() {
-    source = audioCtx.createBufferSource();
-    request = new XMLHttpRequest();
-
-    request.open('GET', 'viper.ogg', true);
-
-    request.responseType = 'arraybuffer';
-
-
-    request.onload = function() {
-      let audioData = request.response;
-
-      audioCtx.decodeAudioData(audioData, function(buffer) {
-          myBuffer = buffer;
-          source.buffer = myBuffer;
-
-          source.connect(panner);
-          panner.connect(audioCtx.destination);
-          positionPanner();
-          source.loop = true;
-        },
-
-        function(e){
-          console.log("Error with decoding audio data" + e.err);
+    fetch("viper.ogg")
+      .then((response) => response.arrayBuffer())
+      .then((downloadedBuffer) => audioCtx.decodeAudioData(downloadedBuffer))
+      .then((decodedBuffer) => {
+        source = new AudioBufferSourceNode(audioCtx, {
+          buffer: decodedBuffer
         });
-
-    };
-
-    request.send();
+        source.connect(panner);
+        panner.connect(audioCtx.destination);
+        positionPanner();
+        source.loop = true;
+        console.log("Loaded!");
+        source.start(0);
+      })
+      .catch((e) => {
+        console.error(`Error while preparing the audio data ${e.err}`);
+      }
+    );
   }
 
   getData();
 
   // controls to move left and right past the boom box
   // and zoom in and out
-
   function moveRight() {
     boomX += -xIterator;
     xPos += -0.066;
@@ -146,8 +128,7 @@ function init() {
       xPos = (WIDTH/2) - 5;
     }
 
-    boomBox.style.webkitTransform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
-    boomBox.style.transform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
+    boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
     positionPanner();
     rightLoop = requestAnimationFrame(moveRight);
     return rightLoop;
@@ -163,8 +144,7 @@ function init() {
     }
 
     positionPanner();
-    boomBox.style.webkitTransform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
-    boomBox.style.transform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
+    boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
     leftLoop = requestAnimationFrame(moveLeft);
     return leftLoop;
   }
@@ -179,8 +159,7 @@ function init() {
     }
 
     positionPanner();
-    boomBox.style.webkitTransform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
-    boomBox.style.transform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
+    boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
     zoomInLoop = requestAnimationFrame(zoomIn);
     return zoomInLoop;
   }
@@ -195,8 +174,7 @@ function init() {
     }
 
     positionPanner();
-    boomBox.style.webkitTransform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
-    boomBox.style.transform = "translate(" + boomX + "px , " + boomY + "px) scale(" + boomZoom + ")";
+    boomBox.style.transform = boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
     zoomOutLoop = requestAnimationFrame(zoomOut);
     return zoomOutLoop;
   }
@@ -205,41 +183,40 @@ function init() {
   // onmouseup cancels the resulting requestAnimationFrames.
 
   leftButton.onmousedown = moveLeft;
-  leftButton.onmouseup = function () {
-    window.cancelAnimationFrame(leftLoop);
+  leftButton.onmouseup = () => {
+    cancelAnimationFrame(leftLoop);
   };
 
   rightButton.onmousedown = moveRight;
-  rightButton.onmouseup = function () {
-    window.cancelAnimationFrame(rightLoop);
+  rightButton.onmouseup = () => {
+    cancelAnimationFrame(rightLoop);
   };
 
   zoomInButton.onmousedown = zoomIn;
-  zoomInButton.onmouseup = function () {
+  zoomInButton.onmouseup = () => {
     window.cancelAnimationFrame(zoomInLoop);
   };
 
   zoomOutButton.onmousedown = zoomOut;
-  zoomOutButton.onmouseup = function () {
+  zoomOutButton.onmouseup = () => {
     window.cancelAnimationFrame(zoomOutLoop);
   };
 }
-// wire up buttons to stop and play audio
 
-stop.setAttribute('disabled', 'disabled');
+// Wire up buttons to stop and play audio
+stopBtn.disabled = true;
 
-play.onclick = function() {
+playBtn.onclick = () => {
   init();
-  source.start(0);
 
-  play.setAttribute('disabled', 'disabled');
-  stop.removeAttribute('disabled');
-  pulseWrapper.classList.add('pulsate');
+  playBtn.disabled = true;
+  stopBtn.disabled = false;
+  pulseWrapper.classList.add('pulsate')
 };
 
-stop.onclick = function() {
+stopBtn.onclick = () => {
   source.stop(0);
-  stop.setAttribute('disabled', 'disabled');
-  play.removeAttribute('disabled');
+  playBtn.disabled = false;
+  stopBtn.disabled = true;
   pulseWrapper.classList.remove('pulsate');
 };

--- a/panner-node/main.js
+++ b/panner-node/main.js
@@ -2,33 +2,33 @@
 let WIDTH = window.innerWidth;
 let HEIGHT = window.innerHeight;
 
-let xPos = Math.floor(WIDTH/2);
-let yPos = Math.floor(HEIGHT/2);
+let xPos = Math.floor(WIDTH / 2);
+let yPos = Math.floor(HEIGHT / 2);
 let zPos = 295;
 
 // play, stop, and other important dom nodes
 
-const playBtn = document.querySelector('.play');
-const stopBtn = document.querySelector('.stop');
-const boomBox = document.querySelector('.boom-box');
-const listenerData = document.querySelector('.listener-data');
-const pannerData = document.querySelector('.panner-data');
-const pulseWrapper = document.querySelector('.pulse-wrapper');
+const playBtn = document.querySelector(".play");
+const stopBtn = document.querySelector(".stop");
+const boomBox = document.querySelector(".boom-box");
+const listenerData = document.querySelector(".listener-data");
+const pannerData = document.querySelector(".panner-data");
+const pulseWrapper = document.querySelector(".pulse-wrapper");
 
 //  movement controls and initial data
 
-const leftButton = document.querySelector('.left');
-const rightButton = document.querySelector('.right');
-const zoomInButton = document.querySelector('.zoom-in');
-const zoomOutButton = document.querySelector('.zoom-out');
+const leftButton = document.querySelector(".left");
+const rightButton = document.querySelector(".right");
+const zoomInButton = document.querySelector(".zoom-in");
+const zoomOutButton = document.querySelector(".zoom-out");
 
 let boomX = 0;
 let boomY = 0;
-let boomZoom = 0.50;
+let boomZoom = 0.5;
 
 // Variables to hold information that needs to be assigned upon play
 // Audio context must be created only after the user has interacted.
-let audioCtx; 
+let audioCtx;
 let panner;
 let listener;
 let source;
@@ -39,8 +39,8 @@ function init() {
   console.log(listener);
 
   panner = new PannerNode(audioCtx, {
-    panningModel: 'HRTF',
-    distanceModel: 'inverse',
+    panningModel: "HRTF",
+    distanceModel: "inverse",
     refDistance: 1,
     maxDistance: 10000,
     rolloffFactor: 1,
@@ -49,7 +49,7 @@ function init() {
     coneOuterGain: 0,
     orientationX: 1,
     orientationY: 0,
-    orientationZ: 0
+    orientationZ: 0,
   });
 
   if (!listener.forwardX) {
@@ -65,10 +65,10 @@ function init() {
     listener.upZ.value = 0;
   }
 
-  leftBound = (-xPos) + 50;
+  leftBound = -xPos + 50;
   rightBound = xPos - 50;
 
-  xIterator = WIDTH/150;
+  xIterator = WIDTH / 150;
 
   // listener will always be in the same place for this demo
 
@@ -93,14 +93,14 @@ function init() {
   }
 
   // Fetch an audio track, decode it and stick it in a buffer.
-  // Then we put the buffer into the source
+  // Then we put the buffer into the source and start it
   function getData() {
     fetch("viper.ogg")
       .then((response) => response.arrayBuffer())
       .then((downloadedBuffer) => audioCtx.decodeAudioData(downloadedBuffer))
       .then((decodedBuffer) => {
         source = new AudioBufferSourceNode(audioCtx, {
-          buffer: decodedBuffer
+          buffer: decodedBuffer,
         });
         source.connect(panner);
         panner.connect(audioCtx.destination);
@@ -111,8 +111,7 @@ function init() {
       })
       .catch((e) => {
         console.error(`Error while preparing the audio data ${e.err}`);
-      }
-    );
+      });
   }
 
   getData();
@@ -123,9 +122,9 @@ function init() {
     boomX += -xIterator;
     xPos += -0.066;
 
-    if(boomX <= leftBound) {
+    if (boomX <= leftBound) {
       boomX = leftBound;
-      xPos = (WIDTH/2) - 5;
+      xPos = WIDTH / 2 - 5;
     }
 
     boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
@@ -138,9 +137,9 @@ function init() {
     boomX += xIterator;
     xPos += 0.066;
 
-    if(boomX > rightBound) {
+    if (boomX > rightBound) {
       boomX = rightBound;
-      xPos = (WIDTH/2) + 5;
+      xPos = WIDTH / 2 + 5;
     }
 
     positionPanner();
@@ -153,7 +152,7 @@ function init() {
     boomZoom += 0.05;
     zPos += 0.066;
 
-    if(boomZoom > 4) {
+    if (boomZoom > 4) {
       boomZoom = 4;
       zPos = 299.9;
     }
@@ -168,20 +167,20 @@ function init() {
     boomZoom += -0.05;
     zPos += -0.066;
 
-    if(boomZoom <= 0.5) {
+    if (boomZoom <= 0.5) {
       boomZoom = 0.5;
       zPos = 295;
     }
 
     positionPanner();
-    boomBox.style.transform = boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
+    boomBox.style.transform =
+      boomBox.style.transform = `translate(${boomX}px, ${boomY}px) scale(${boomZoom})`;
     zoomOutLoop = requestAnimationFrame(zoomOut);
     return zoomOutLoop;
   }
 
   // In each of the cases below, onmousedown runs the functions above
   // onmouseup cancels the resulting requestAnimationFrames.
-
   leftButton.onmousedown = moveLeft;
   leftButton.onmouseup = () => {
     cancelAnimationFrame(leftLoop);
@@ -208,15 +207,14 @@ stopBtn.disabled = true;
 
 playBtn.onclick = () => {
   init();
-
   playBtn.disabled = true;
   stopBtn.disabled = false;
-  pulseWrapper.classList.add('pulsate')
+  pulseWrapper.classList.add("pulsate");
 };
 
 stopBtn.onclick = () => {
   source.stop(0);
   playBtn.disabled = false;
   stopBtn.disabled = true;
-  pulseWrapper.classList.remove('pulsate');
+  pulseWrapper.classList.remove("pulsate");
 };


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the panner-node example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use literal string where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
  - Improve instruction
- Use promise versions of API if possible.
- Use `fetch()` instead of XHR
- Fix a link to an `http://` url to an `https://` so it actually works in browsers (mixed content error)
- Replace `.innerHTML` properties with `.textContent`

Tested on Firefox, Safari, and Chrome (macOS) via a local server.