### PR TITLE
Update step sequencer to modern JS

### DIFF
--- a/step-sequencer/index.html
+++ b/step-sequencer/index.html
@@ -32,7 +32,8 @@
           step="1"
         />
         <span id="bpmval">120</span>
-        <button data-playing="false">Play</button>
+        <input type="checkbox" id="playBtn" />
+        <label for="playBtn">Play</label>
       </section>
 
       <div id="tracks">
@@ -63,20 +64,19 @@
           </section>
           <!--
 
-        -->
+          -->
           <section class="pads">
-            <button role="switch" aria-checked="false">
-              <span>Voice 1, Note 1</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 1, Note 2</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 1, Note 3</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 1, Note 4</span>
-            </button>
+            <input type="checkbox" id="v1n1" />
+            <label for="v1n1">Voice 1, Note 1</label>
+
+            <input type="checkbox" id="v1n2" />
+            <label for="v1n2">Voice 1, Note 2</label>
+
+            <input type="checkbox" id="v1n3" />
+            <label for="v1n3">Voice 1, Note 3</label>
+
+            <input type="checkbox" id="v1n4" />
+            <label for="v1n4">Voice 1, Note 4</label>
           </section>
         </section>
 
@@ -107,20 +107,19 @@
           </section>
           <!--
 
-        -->
+          -->
           <section class="pads">
-            <button role="switch" aria-checked="false">
-              <span>Voice 2, Note 1</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 2, Note 2</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 2, Note 3</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 2, Note 4</span>
-            </button>
+            <input type="checkbox" id="v2n1" />
+            <label for="v2n1">Voice 2, Note 1</label>
+
+            <input type="checkbox" id="v1n2" />
+            <label for="v2n2">Voice 2, Note 2</label>
+
+            <input type="checkbox" id="v1n3" />
+            <label for="v2n3">Voice 2, Note 3</label>
+
+            <input type="checkbox" id="v1n4" />
+            <label for="v2n4">Voice 2, Note 4</label>
           </section>
         </section>
 
@@ -151,20 +150,19 @@
           </section>
           <!--
 
-        -->
+          -->
           <section class="pads">
-            <button role="switch" aria-checked="false">
-              <span>Voice 3, Note 1</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 3, Note 2</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 3, Note 3</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 3, Note 4</span>
-            </button>
+            <input type="checkbox" id="v3n1" />
+            <label for="v3n1">Voice 3, Note 1</label>
+
+            <input type="checkbox" id="v3n2" />
+            <label for="v3n2">Voice 3, Note 2</label>
+
+            <input type="checkbox" id="v3n3" />
+            <label for="v3n3">Voice 3, Note 3</label>
+
+            <input type="checkbox" id="v3n4" />
+            <label for="v3n4">Voice 3, Note 4</label>
           </section>
         </section>
 
@@ -185,20 +183,19 @@
           </section>
           <!--
 
-        -->
+          -->
           <section class="pads">
-            <button role="switch" aria-checked="false">
-              <span>Voice 4, Note 1</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 4, Note 2</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 4, Note 3</span>
-            </button>
-            <button role="switch" aria-checked="false">
-              <span>Voice 4, Note 4</span>
-            </button>
+            <input type="checkbox" id="v4n1" />
+            <label for="v4n1">Voice 4, Note 1</label>
+
+            <input type="checkbox" id="v4n2" />
+            <label for="v4n2">Voice 4, Note 2</label>
+
+            <input type="checkbox" id="v4n3" />
+            <label for="v4n3">Voice 4, Note 3</label>
+
+            <input type="checkbox" id="v4n4" />
+            <label for="v4n4">Voice 4, Note 4</label>
           </section>
         </section>
       </div>
@@ -216,23 +213,7 @@
 
       // Before we do anything more, let's grab our checkboxes from the interface. We want to keep them in the groups they are in as each row represents a different sound or _voice_.
       const pads = document.querySelectorAll(".pads");
-      const allPadButtons = document.querySelectorAll("#tracks button");
-
-      // Toggle aria attribute on click
-      allPadButtons.forEach((el) => {
-        el.addEventListener(
-          "click",
-          () => {
-            if (el.getAttribute("aria-checked") === "false") {
-              el.setAttribute("aria-checked", "true");
-            } else {
-              el.setAttribute("aria-checked", "false");
-            }
-          },
-          false
-        );
-      });
-
+      
       const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
 
       // let noteTime = 1;
@@ -437,7 +418,7 @@
         nextNoteTime += secondsPerBeat; // Add beat length to last beat time
 
         // Advance the beat number, wrap to zero when reaching 4
-        currentNote = ++currentNote % 4;
+        currentNote = (currentNote+1) % 4;
       }
 
       // Create a queue for the notes that are to be played, with the current time that we want them to play:
@@ -445,43 +426,26 @@
       let dtmf;
 
       function scheduleNote(beatNumber, time) {
-        // push the note on the queue, even if we're not playing.
+        // Push the note into the queue, even if we're not playing.
         notesInQueue.push({ note: beatNumber, time: time });
-        // console.log(beatNumber, time);
 
-        if (
-          pads[0]
-            .querySelectorAll("button")
-            [beatNumber].getAttribute("aria-checked") === "true"
-        ) {
+        if (pads[0].querySelectorAll("input")[beatNumber].checked) {
           playSweep(time);
         }
-        if (
-          pads[1]
-            .querySelectorAll("button")
-            [beatNumber].getAttribute("aria-checked") === "true"
-        ) {
+        if (pads[1].querySelectorAll("input")[beatNumber].checked) {
           playPulse(time);
         }
-        if (
-          pads[2]
-            .querySelectorAll("button")
-            [beatNumber].getAttribute("aria-checked") === "true"
-        ) {
+        if (pads[2].querySelectorAll("input")[beatNumber].checked) {
           playNoise(time);
         }
-        if (
-          pads[3]
-            .querySelectorAll("button")
-            [beatNumber].getAttribute("aria-checked") === "true"
-        ) {
+        if (pads[3].querySelectorAll("input")[beatNumber].checked) {
           playSample(audioCtx, dtmf, time);
         }
       }
 
       let timerID;
       function scheduler() {
-        // while there are notes that will need to play before the next interval,
+        // While there are notes that will need to play before the next interval,
         // schedule them and advance the pointer.
         while (nextNoteTime < audioCtx.currentTime + scheduleAheadTime) {
           scheduleNote(currentNote, nextNoteTime);
@@ -490,7 +454,8 @@
         timerID = setTimeout(scheduler, lookahead);
       }
 
-      // We also need a draw function to update the UI, so we can see when the beat progresses.
+      // Draw function to update the UI, so we can see when the beat progress.
+      // This is a loop: it reschudele itself to redraw at the end.
       let lastNoteDrawn = 3;
       function draw() {
         let drawNote = lastNoteDrawn;
@@ -498,15 +463,14 @@
 
         while (notesInQueue.length && notesInQueue[0].time < currentTime) {
           drawNote = notesInQueue[0].note;
-          notesInQueue.splice(0, 1); // remove note from queue
+          notesInQueue.shift(); // Remove note from queue
         }
 
         // We only need to draw if the note has moved.
         if (lastNoteDrawn !== drawNote) {
-          pads.forEach((el) => {
-            el.children[lastNoteDrawn].style.borderColor =
-              "hsla(0, 0%, 10%, 1)";
-            el.children[drawNote].style.borderColor = "hsla(49, 99%, 50%, 1)";
+          pads.forEach((pad) => {
+            pad.children[lastNoteDrawn*2].style.borderColor = "var(--black)";
+            pad.children[drawNote*2].style.borderColor = "var(--yellow)";
           });
 
           lastNoteDrawn = drawNote;
@@ -517,7 +481,7 @@
 
       // when the sample has loaded allow play
       const loadingEl = document.querySelector(".loading");
-      const playButton = document.querySelector("[data-playing]");
+      const playButton = document.querySelector("#playBtn");
       let isPlaying = false;
       setupSample().then((sample) => {
         loadingEl.style.display = "none";

--- a/step-sequencer/index.html
+++ b/step-sequencer/index.html
@@ -205,18 +205,16 @@
     <script src="wavetable.js"></script>
 
     <script type="text/javascript">
-      console.clear();
-
       const audioCtx = new AudioContext();
-
-      // TODO make all frequencies like each other, one day
 
       // Before we do anything more, let's grab our checkboxes from the interface. We want to keep them in the groups they are in as each row represents a different sound or _voice_.
       const pads = document.querySelectorAll(".pads");
       
-      const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
+      const wave = new PeriodicWave(audioCtx, {
+        real: wavetable.real,
+        imag: wavetable.imag
+      });
 
-      // let noteTime = 1;
       let attackTime = 0.2;
       const attackControl = document.querySelector("#attack");
       attackControl.addEventListener(
@@ -240,9 +238,11 @@
       // Expose attack time & release time
       const sweepLength = 2;
       function playSweep(time) {
-        const osc = audioCtx.createOscillator();
-        osc.setPeriodicWave(wave);
-        osc.frequency.value = 380;
+        const osc = new OscillatorNode(audioCtx, {
+          frequency: 380,
+          type: "custom",
+          periodicWave: wave
+        });
 
         const sweepEnv = new GainNode(audioCtx);
         sweepEnv.gain.cancelScheduledValues(time);
@@ -325,27 +325,30 @@
 
       function playNoise(time) {
         const bufferSize = audioCtx.sampleRate * noiseDuration; // set the time of the note
-        const buffer = audioCtx.createBuffer(
-          1,
-          bufferSize,
-          audioCtx.sampleRate
-        ); // create an empty buffer
-        const data = buffer.getChannelData(0); // get data
+        // Create an empty buffer
+        const noiseBuffer = new AudioBuffer({
+          length: bufferSize,
+          sampleRate: audioCtx.sampleRate
+        });
 
-        // fill the buffer with noise
+        // Fill the buffer with noise
+        const data = noiseBuffer.getChannelData(0);
         for (let i = 0; i < bufferSize; i++) {
           data[i] = Math.random() * 2 - 1;
         }
 
-        // create a buffer source for our created data
-        const noise = audioCtx.createBufferSource();
-        noise.buffer = buffer;
+        // Create a buffer source for our created data
+        const noise = new AudioBufferSourceNode(audioCtx, {
+          buffer: noiseBuffer
+        });
 
-        const bandpass = audioCtx.createBiquadFilter();
-        bandpass.type = "bandpass";
-        bandpass.frequency.value = bandHz;
+        // Filter the output
+        const bandpass = new BiquadFilterNode(audioCtx, {
+          type: "bandpass",
+          frequency: bandHz
+        });
 
-        // connect our graph
+        // Connect our graph
         noise.connect(bandpass).connect(audioCtx.destination);
         noise.start(time);
       }

--- a/step-sequencer/index.html
+++ b/step-sequencer/index.html
@@ -1,388 +1,551 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Step Sequencer: MDModemnz</title>
-  <meta name="description" content="Making an instrument with the Web Audio API">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <link rel="stylesheet" type="text/css" href="style.css">
-</head>
-<body>
-  <div class="loading">
-    <p>Loading...</p>
-  </div>
-
-  <div id="sequencer">
-    <section class="controls-main">
-      <h1>ModemDN</h1>
-      <label for="bpm">BPM</label>
-      <input name="bpm" id="bpm" type="range" min="60" max="180" value="120" step="1" />
-      <span id="bpmval">120</span>
-      <button data-playing="false">Play</button>
-    </section>
-
-    <div id="tracks">
-      <!-- track one: bleep -->
-      <section class="track-one">
-        <h2>Sweep</h2>
-        <section class="controls">
-          <label for="attack">Att</label>
-          <input name="attack" id="attack" type="range" min="0" max="1" value="0.2" step="0.1" />
-          <label for="release">Rel</label>
-          <input name="release" id="release" type="range" min="0" max="1" value="0.5" step="0.1" />
-        </section><!--
-
-        --><section class="pads">
-          <button role="switch" aria-checked="false"><span>Voice 1, Note 1</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 1, Note 2</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 1, Note 3</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 1, Note 4</span></button>
-        </section>
-      </section>
-
-      <!-- track two: pad/sweep -->
-      <section class="track-two">
-        <h2>Pulse</h2>
-        <section class="controls">
-          <label for="hz">Hz</label>
-          <input name="hz" id="hz" type="range" min="660" max="1320" value="880" step="1" />
-          <label for="lfo">LFO</label>
-          <input name="lfo" id="lfo" type="range" min="20" max="40" value="30" step="1" />
-        </section><!--
-
-        --><section class="pads">
-          <button role="switch" aria-checked="false"><span>Voice 2, Note 1</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 2, Note 2</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 2, Note 3</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 2, Note 4</span></button>
-        </section>
-      </section>
-
-      <!-- track three: noise -->
-      <section class="track-three">
-        <h2>Noise</h2>
-        <section class="controls">
-          <label for="duration">Dur</label>
-          <input name="duration" id="duration" type="range" min="0" max="2" value="1" step="0.1" />
-          <label for="band">Band</label>
-          <input name="band" id="band" type="range" min="400" max="1200" value="1000" step="5" />
-        </section><!--
-
-        --><section class="pads">
-          <button role="switch" aria-checked="false"><span>Voice 3, Note 1</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 3, Note 2</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 3, Note 3</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 3, Note 4</span></button>
-        </section>
-      </section>
-
-      <!-- track four: drill -->
-      <section class="track-four">
-        <h2>DTMF</h2>
-        <section class="controls">
-          <label for="rate">Rate</label>
-          <input name="rate" id="rate" type="range" min="0.1" max="2" value="1" step="0.1" />
-        </section><!--
-
-        --><section class="pads">
-          <button role="switch" aria-checked="false"><span>Voice 4, Note 1</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 4, Note 2</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 4, Note 3</span></button>
-          <button role="switch" aria-checked="false"><span>Voice 4, Note 4</span></button>
-        </section>
-      </section>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Step Sequencer: MDModemnz</title>
+    <meta
+      name="description"
+      content="Making an instrument with the Web Audio API"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="stylesheet" type="text/css" href="style.css" />
+  </head>
+  <body>
+    <div class="loading">
+      <p>Loading...</p>
     </div>
-  </div><!-- sequencer -->
 
-<script src="wavetable.js"></script>
+    <div id="sequencer">
+      <section class="controls-main">
+        <h1>ModemDN</h1>
+        <label for="bpm">BPM</label>
+        <input
+          name="bpm"
+          id="bpm"
+          type="range"
+          min="60"
+          max="180"
+          value="120"
+          step="1"
+        />
+        <span id="bpmval">120</span>
+        <button data-playing="false">Play</button>
+      </section>
 
-<script type="text/javascript">
-console.clear();
+      <div id="tracks">
+        <!-- track one: bleep -->
+        <section class="track-one">
+          <h2>Sweep</h2>
+          <section class="controls">
+            <label for="attack">Att</label>
+            <input
+              name="attack"
+              id="attack"
+              type="range"
+              min="0"
+              max="1"
+              value="0.2"
+              step="0.1"
+            />
+            <label for="release">Rel</label>
+            <input
+              name="release"
+              id="release"
+              type="range"
+              min="0"
+              max="1"
+              value="0.5"
+              step="0.1"
+            />
+          </section>
+          <!--
 
-// ! You should just be able to do 
-// const audioCtx = new AudioContext();
-// but this allows for Safari support !
-const audioCtx = window.AudioContext ? new AudioContext() : new webkitAudioContext();
+        -->
+          <section class="pads">
+            <button role="switch" aria-checked="false">
+              <span>Voice 1, Note 1</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 1, Note 2</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 1, Note 3</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 1, Note 4</span>
+            </button>
+          </section>
+        </section>
 
-// TODO make all frequencies like each other, one day
+        <!-- track two: pad/sweep -->
+        <section class="track-two">
+          <h2>Pulse</h2>
+          <section class="controls">
+            <label for="hz">Hz</label>
+            <input
+              name="hz"
+              id="hz"
+              type="range"
+              min="660"
+              max="1320"
+              value="880"
+              step="1"
+            />
+            <label for="lfo">LFO</label>
+            <input
+              name="lfo"
+              id="lfo"
+              type="range"
+              min="20"
+              max="40"
+              value="30"
+              step="1"
+            />
+          </section>
+          <!--
 
-// Before we do anything more, let's grab our checkboxes from the interface. We want to keep them in the groups they are in as each row represents a different sound or _voice_.
-const pads = document.querySelectorAll('.pads');
-const allPadButtons = document.querySelectorAll('#tracks button');
+        -->
+          <section class="pads">
+            <button role="switch" aria-checked="false">
+              <span>Voice 2, Note 1</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 2, Note 2</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 2, Note 3</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 2, Note 4</span>
+            </button>
+          </section>
+        </section>
 
-// switch aria attribute on click
-allPadButtons.forEach(el => {
-  el.addEventListener('click', () => {
-    if (el.getAttribute('aria-checked') === 'false') {
-      el.setAttribute('aria-checked', 'true');
-    } else {
-      el.setAttribute('aria-checked', 'false');
-    }
-  }, false)
-})
+        <!-- track three: noise -->
+        <section class="track-three">
+          <h2>Noise</h2>
+          <section class="controls">
+            <label for="duration">Dur</label>
+            <input
+              name="duration"
+              id="duration"
+              type="range"
+              min="0"
+              max="2"
+              value="1"
+              step="0.1"
+            />
+            <label for="band">Band</label>
+            <input
+              name="band"
+              id="band"
+              type="range"
+              min="400"
+              max="1200"
+              value="1000"
+              step="5"
+            />
+          </section>
+          <!--
 
-const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
+        -->
+          <section class="pads">
+            <button role="switch" aria-checked="false">
+              <span>Voice 3, Note 1</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 3, Note 2</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 3, Note 3</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 3, Note 4</span>
+            </button>
+          </section>
+        </section>
 
-// let noteTime = 1;
-let attackTime = 0.2;
-const attackControl = document.querySelector('#attack');
-attackControl.addEventListener('input', ev => {
-  attackTime = Number(ev.target.value);
-}, false);
+        <!-- track four: drill -->
+        <section class="track-four">
+          <h2>DTMF</h2>
+          <section class="controls">
+            <label for="rate">Rate</label>
+            <input
+              name="rate"
+              id="rate"
+              type="range"
+              min="0.1"
+              max="2"
+              value="1"
+              step="0.1"
+            />
+          </section>
+          <!--
 
-let releaseTime = 0.5;
-const releaseControl = document.querySelector('#release');
-releaseControl.addEventListener('input', ev => {
-  releaseTime = Number(ev.target.value);
-}, false);
+        -->
+          <section class="pads">
+            <button role="switch" aria-checked="false">
+              <span>Voice 4, Note 1</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 4, Note 2</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 4, Note 3</span>
+            </button>
+            <button role="switch" aria-checked="false">
+              <span>Voice 4, Note 4</span>
+            </button>
+          </section>
+        </section>
+      </div>
+    </div>
+    <!-- sequencer -->
 
-const sweepLength = 2;
-// expose attack time & release time
-function playSweep(time) {
-  const osc = audioCtx.createOscillator();
-  osc.setPeriodicWave(wave);
-  osc.frequency.value = 380;
+    <script src="wavetable.js"></script>
 
-  const sweepEnv = audioCtx.createGain();
-  sweepEnv.gain.cancelScheduledValues(time);
-  sweepEnv.gain.setValueAtTime(0, time);
-  sweepEnv.gain.linearRampToValueAtTime(1, time + attackTime);
-  sweepEnv.gain.linearRampToValueAtTime(0, time + sweepLength - releaseTime);
+    <script type="text/javascript">
+      console.clear();
 
-  osc.connect(sweepEnv).connect(audioCtx.destination);
-  osc.start(time);
-  osc.stop(time + sweepLength);
-}
+      const audioCtx = new AudioContext();
 
+      // TODO make all frequencies like each other, one day
 
-// expose frequency & frequency modulation
-let pulseHz = 880;
-const hzControl = document.querySelector('#hz');
-hzControl.addEventListener('input', ev => {
-  pulseHz = Number(ev.target.value);
-}, false);
+      // Before we do anything more, let's grab our checkboxes from the interface. We want to keep them in the groups they are in as each row represents a different sound or _voice_.
+      const pads = document.querySelectorAll(".pads");
+      const allPadButtons = document.querySelectorAll("#tracks button");
 
-let lfoHz = 30;
-const lfoControl = document.querySelector('#lfo');
-lfoControl.addEventListener('input', ev => {
-  lfoHz = Number(ev.target.value);
-}, false);
+      // Toggle aria attribute on click
+      allPadButtons.forEach((el) => {
+        el.addEventListener(
+          "click",
+          () => {
+            if (el.getAttribute("aria-checked") === "false") {
+              el.setAttribute("aria-checked", "true");
+            } else {
+              el.setAttribute("aria-checked", "false");
+            }
+          },
+          false
+        );
+      });
 
-const pulseTime = 1;
-function playPulse(time) {
-  const osc = audioCtx.createOscillator();
-  osc.type = 'sine';
-  osc.frequency.value = pulseHz;
+      const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
 
-  const amp = audioCtx.createGain();
-  amp.gain.value = 1;
+      // let noteTime = 1;
+      let attackTime = 0.2;
+      const attackControl = document.querySelector("#attack");
+      attackControl.addEventListener(
+        "input",
+        (ev) => {
+          attackTime = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-  const lfo = audioCtx.createOscillator();
-  lfo.type = 'square';
-  lfo.frequency.value = lfoHz;
+      let releaseTime = 0.5;
+      const releaseControl = document.querySelector("#release");
+      releaseControl.addEventListener(
+        "input",
+        (ev) => {
+          releaseTime = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-  lfo.connect(amp.gain);
-  osc.connect(amp).connect(audioCtx.destination);
-  lfo.start();
-  osc.start(time);
-  osc.stop(time + pulseTime);
-}
+      // Expose attack time & release time
+      const sweepLength = 2;
+      function playSweep(time) {
+        const osc = audioCtx.createOscillator();
+        osc.setPeriodicWave(wave);
+        osc.frequency.value = 380;
 
+        const sweepEnv = new GainNode(audioCtx);
+        sweepEnv.gain.cancelScheduledValues(time);
+        sweepEnv.gain.setValueAtTime(0, time);
+        sweepEnv.gain.linearRampToValueAtTime(1, time + attackTime);
+        sweepEnv.gain.linearRampToValueAtTime(
+          0,
+          time + sweepLength - releaseTime
+        );
 
-// expose noteDuration & band frequency
-let noiseDuration = 1;
-const durControl = document.querySelector('#duration');
-durControl.addEventListener('input', ev => {
-  noiseDuration = Number(ev.target.value);
-}, false);
+        osc.connect(sweepEnv).connect(audioCtx.destination);
+        osc.start(time);
+        osc.stop(time + sweepLength);
+      }
 
-let bandHz = 1000;
-const bandControl = document.querySelector('#band');
-bandControl.addEventListener('input', ev => {
-  bandHz = Number(ev.target.value);
-}, false);
+      // Expose frequency & frequency modulation
+      let pulseHz = 880;
+      const hzControl = document.querySelector("#hz");
+      hzControl.addEventListener(
+        "input",
+        (ev) => {
+          pulseHz = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-function playNoise(time) {
-  const bufferSize = audioCtx.sampleRate * noiseDuration; // set the time of the note
-  const buffer = audioCtx.createBuffer(1, bufferSize, audioCtx.sampleRate); // create an empty buffer
-  const data = buffer.getChannelData(0); // get data
+      let lfoHz = 30;
+      const lfoControl = document.querySelector("#lfo");
+      lfoControl.addEventListener(
+        "input",
+        (ev) => {
+          lfoHz = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-  // fill the buffer with noise
-  for (let i = 0; i < bufferSize; i++) {
-    data[i] = Math.random() * 2 - 1;
-  }
+      const pulseTime = 1;
+      function playPulse(time) {
+        const osc = new OscillatorNode(audioCtx, {
+          type: "sine",
+          frequency: pulseHz,
+        });
 
-  // create a buffer source for our created data
-  const noise = audioCtx.createBufferSource();
-  noise.buffer = buffer;
+        const amp = new GainNode(audioCtx, {
+          value: 1,
+        });
 
-  const bandpass = audioCtx.createBiquadFilter();
-  bandpass.type = 'bandpass';
-  bandpass.frequency.value = bandHz;
+        const lfo = new OscillatorNode(audioCtx, {
+          type: "square",
+          frequency: lfoHz,
+        });
 
-  // connect our graph
-  noise.connect(bandpass).connect(audioCtx.destination);
-  noise.start(time);
-}
+        lfo.connect(amp.gain);
+        osc.connect(amp).connect(audioCtx.destination);
+        lfo.start();
+        osc.start(time);
+        osc.stop(time + pulseTime);
+      }
 
-// Loading ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// fetch the audio file and decode the data
-async function getFile(audioContext, filepath) {
-  const response = await fetch(filepath);
-  const arrayBuffer = await response.arrayBuffer();
-  // ! A callback has been added here as a second param for Safari only !
-  const audioBuffer = await audioContext.decodeAudioData(arrayBuffer, function() {return});
-  return audioBuffer;
-}
+      // Expose noteDuration & band frequency
+      let noiseDuration = 1;
+      const durControl = document.querySelector("#duration");
+      durControl.addEventListener(
+        "input",
+        (ev) => {
+          noiseDuration = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-let playbackRate = 1;
-const rateControl = document.querySelector('#rate');
-rateControl.addEventListener('input', ev => {
-  playbackRate = Number(ev.target.value);
-}, false);
+      let bandHz = 1000;
+      const bandControl = document.querySelector("#band");
+      bandControl.addEventListener(
+        "input",
+        (ev) => {
+          bandHz = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-// create a buffer, plop in data, connect and play -> modify graph here if required
-function playSample(audioContext, audioBuffer, time) {
-  const sampleSource = audioContext.createBufferSource();
-  sampleSource.buffer = audioBuffer;
-  sampleSource.playbackRate.value = playbackRate;
-  sampleSource.connect(audioContext.destination)
-  sampleSource.start(time);
-  return sampleSource;
-}
+      function playNoise(time) {
+        const bufferSize = audioCtx.sampleRate * noiseDuration; // set the time of the note
+        const buffer = audioCtx.createBuffer(
+          1,
+          bufferSize,
+          audioCtx.sampleRate
+        ); // create an empty buffer
+        const data = buffer.getChannelData(0); // get data
 
-async function setupSample() {
-  const filePath = 'dtmf.mp3';
-  // Here we're `await`ing the async/promise that is `getFile`.
-  // To be able to use this keyword we need to be within an `async` function
-  const sample = await getFile(audioCtx, filePath);
-  return sample;
-}
-
-
-// Scheduling ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-let tempo = 60.0;
-const bpmControl = document.querySelector('#bpm');
-const bpmValEl = document.querySelector('#bpmval');
-
-bpmControl.addEventListener('input', ev => {
-  tempo = Number(ev.target.value);
-  bpmValEl.innerText = tempo;
-}, false);
-
-const lookahead = 25.0; // How frequently to call scheduling function (in milliseconds)
-const scheduleAheadTime = 0.1; // How far ahead to schedule audio (sec)
-
-let currentNote = 0; // The note we are currently playing
-let nextNoteTime = 0.0; // when the next note is due.
-function nextNote() {
-  const secondsPerBeat = 60.0 / tempo;
-
-  nextNoteTime += secondsPerBeat; // Add beat length to last beat time
-
-  // Advance the beat number, wrap to zero
-  currentNote++;
-  if (currentNote === 4) {
-    currentNote = 0;
-  }
-
-}
-
-// Create a queue for the notes that are to be played, with the current time that we want them to play:
-const notesInQueue = [];
-let dtmf;
-
-function scheduleNote(beatNumber, time) {
-  // push the note on the queue, even if we're not playing.
-  notesInQueue.push({note: beatNumber, time: time});
-  // console.log(beatNumber, time);
-
-  if (pads[0].querySelectorAll('button')[beatNumber].getAttribute('aria-checked') === 'true') {
-    playSweep(time);
-  }
-  if (pads[1].querySelectorAll('button')[beatNumber].getAttribute('aria-checked') === 'true') {
-    playPulse(time);
-  }
-  if (pads[2].querySelectorAll('button')[beatNumber].getAttribute('aria-checked') === 'true') {
-    playNoise(time);
-  }
-  if (pads[3].querySelectorAll('button')[beatNumber].getAttribute('aria-checked') === 'true') {
-    playSample(audioCtx, dtmf, time);
-  }
-
-}
-
-let timerID;
-function scheduler() {
-  // while there are notes that will need to play before the next interval,
-  // schedule them and advance the pointer.
-  while (nextNoteTime < audioCtx.currentTime + scheduleAheadTime ) {
-      scheduleNote(currentNote, nextNoteTime);
-      nextNote();
-  }
-  timerID = window.setTimeout(scheduler, lookahead);
-}
-
-// We also need a draw function to update the UI, so we can see when the beat progresses.
-
-let lastNoteDrawn = 3;
-function draw() {
-  let drawNote = lastNoteDrawn;
-  const currentTime = audioCtx.currentTime;
-
-  while (notesInQueue.length && notesInQueue[0].time < currentTime) {
-    drawNote = notesInQueue[0].note;
-    notesInQueue.splice(0,1);   // remove note from queue
-  }
-
-  // We only need to draw if the note has moved.
-  if (lastNoteDrawn !== drawNote) {
-    pads.forEach(el => {
-      el.children[lastNoteDrawn].style.borderColor = 'hsla(0, 0%, 10%, 1)';
-      el.children[drawNote].style.borderColor = 'hsla(49, 99%, 50%, 1)';
-    });
-
-    lastNoteDrawn = drawNote;
-  }
-  // set up to draw again
-  requestAnimationFrame(draw);
-}
-
-// when the sample has loaded allow play
-const loadingEl = document.querySelector('.loading');
-const playButton = document.querySelector('[data-playing]');
-let isPlaying = false;
-setupSample()
-  .then((sample) => {
-    loadingEl.style.display = 'none';
-
-    dtmf = sample; // to be used in our playSample function
-
-    playButton.addEventListener('click', ev => {
-      isPlaying = !isPlaying;
-
-      if (isPlaying) { // start playing
-
-        // check if context is in suspended state (autoplay policy)
-        if (audioCtx.state === 'suspended') {
-          audioCtx.resume();
+        // fill the buffer with noise
+        for (let i = 0; i < bufferSize; i++) {
+          data[i] = Math.random() * 2 - 1;
         }
 
-        currentNote = 0;
-        nextNoteTime = audioCtx.currentTime;
-        scheduler(); // kick off scheduling
-        requestAnimationFrame(draw); // start the drawing loop.
-        ev.target.dataset.playing = 'true';
-      } else {
-        window.clearTimeout(timerID);
-        ev.target.dataset.playing = 'false';
+        // create a buffer source for our created data
+        const noise = audioCtx.createBufferSource();
+        noise.buffer = buffer;
+
+        const bandpass = audioCtx.createBiquadFilter();
+        bandpass.type = "bandpass";
+        bandpass.frequency.value = bandHz;
+
+        // connect our graph
+        noise.connect(bandpass).connect(audioCtx.destination);
+        noise.start(time);
       }
-    })
-  });
 
+      // Loading the file: fetch the audio file and decode the data
+      async function getFile(audioContext, filepath) {
+        const response = await fetch(filepath);
+        const arrayBuffer = await response.arrayBuffer();
+        // ! A callback has been added here as a second param for Safari only !
+        const audioBuffer = await audioContext.decodeAudioData(
+          arrayBuffer,
+          function () {
+            return;
+          }
+        );
+        return audioBuffer;
+      }
 
+      let playbackRate = 1;
+      const rateControl = document.querySelector("#rate");
+      rateControl.addEventListener(
+        "input",
+        (ev) => {
+          playbackRate = parseInt(ev.target.value, 10);
+        },
+        false
+      );
 
-</script>
-</body>
+      // Create a buffer, plop in data, connect and play -> modify graph here if required
+      function playSample(audioContext, audioBuffer, time) {
+        const sampleSource = new AudioBufferSourceNode(audioCtx, {
+          buffer: audioBuffer,
+          playbackRate: playbackRate,
+        });
+        sampleSource.connect(audioContext.destination);
+        sampleSource.start(time);
+        return sampleSource;
+      }
+
+      async function setupSample() {
+        const filePath = "dtmf.mp3";
+        // Here we're waiting for the load of the file
+        // To be able to use this keyword we need to be within an `async` function
+        const sample = await getFile(audioCtx, filePath);
+        return sample;
+      }
+
+      // Scheduling
+      let tempo = 60.0;
+      const bpmControl = document.querySelector("#bpm");
+      const bpmValEl = document.querySelector("#bpmval");
+
+      bpmControl.addEventListener(
+        "input",
+        (ev) => {
+          tempo = parseInt(ev.target.value, 10);
+          bpmValEl.innerText = tempo;
+        },
+        false
+      );
+
+      const lookahead = 25.0; // How frequently to call scheduling function (in milliseconds)
+      const scheduleAheadTime = 0.1; // How far ahead to schedule audio (sec)
+
+      let currentNote = 0; // The note we are currently playing
+      let nextNoteTime = 0.0; // when the next note is due.
+      function nextNote() {
+        const secondsPerBeat = 60.0 / tempo;
+
+        nextNoteTime += secondsPerBeat; // Add beat length to last beat time
+
+        // Advance the beat number, wrap to zero when reaching 4
+        currentNote = ++currentNote % 4;
+      }
+
+      // Create a queue for the notes that are to be played, with the current time that we want them to play:
+      const notesInQueue = [];
+      let dtmf;
+
+      function scheduleNote(beatNumber, time) {
+        // push the note on the queue, even if we're not playing.
+        notesInQueue.push({ note: beatNumber, time: time });
+        // console.log(beatNumber, time);
+
+        if (
+          pads[0]
+            .querySelectorAll("button")
+            [beatNumber].getAttribute("aria-checked") === "true"
+        ) {
+          playSweep(time);
+        }
+        if (
+          pads[1]
+            .querySelectorAll("button")
+            [beatNumber].getAttribute("aria-checked") === "true"
+        ) {
+          playPulse(time);
+        }
+        if (
+          pads[2]
+            .querySelectorAll("button")
+            [beatNumber].getAttribute("aria-checked") === "true"
+        ) {
+          playNoise(time);
+        }
+        if (
+          pads[3]
+            .querySelectorAll("button")
+            [beatNumber].getAttribute("aria-checked") === "true"
+        ) {
+          playSample(audioCtx, dtmf, time);
+        }
+      }
+
+      let timerID;
+      function scheduler() {
+        // while there are notes that will need to play before the next interval,
+        // schedule them and advance the pointer.
+        while (nextNoteTime < audioCtx.currentTime + scheduleAheadTime) {
+          scheduleNote(currentNote, nextNoteTime);
+          nextNote();
+        }
+        timerID = setTimeout(scheduler, lookahead);
+      }
+
+      // We also need a draw function to update the UI, so we can see when the beat progresses.
+      let lastNoteDrawn = 3;
+      function draw() {
+        let drawNote = lastNoteDrawn;
+        const currentTime = audioCtx.currentTime;
+
+        while (notesInQueue.length && notesInQueue[0].time < currentTime) {
+          drawNote = notesInQueue[0].note;
+          notesInQueue.splice(0, 1); // remove note from queue
+        }
+
+        // We only need to draw if the note has moved.
+        if (lastNoteDrawn !== drawNote) {
+          pads.forEach((el) => {
+            el.children[lastNoteDrawn].style.borderColor =
+              "hsla(0, 0%, 10%, 1)";
+            el.children[drawNote].style.borderColor = "hsla(49, 99%, 50%, 1)";
+          });
+
+          lastNoteDrawn = drawNote;
+        }
+        // Set up to draw again
+        requestAnimationFrame(draw);
+      }
+
+      // when the sample has loaded allow play
+      const loadingEl = document.querySelector(".loading");
+      const playButton = document.querySelector("[data-playing]");
+      let isPlaying = false;
+      setupSample().then((sample) => {
+        loadingEl.style.display = "none";
+
+        dtmf = sample; // to be used in our playSample function
+
+        playButton.addEventListener("click", (ev) => {
+          isPlaying = !isPlaying;
+
+          if (isPlaying) {
+            // start playing
+
+            // check if context is in suspended state (autoplay policy)
+            if (audioCtx.state === "suspended") {
+              audioCtx.resume();
+            }
+
+            currentNote = 0;
+            nextNoteTime = audioCtx.currentTime;
+            scheduler(); // kick off scheduling
+            requestAnimationFrame(draw); // start the drawing loop.
+            ev.target.dataset.playing = "true";
+          } else {
+            window.clearTimeout(timerID);
+            ev.target.dataset.playing = "false";
+          }
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/step-sequencer/style.css
+++ b/step-sequencer/style.css
@@ -100,7 +100,7 @@ h2 {
 }
 
 /* play button */
-[data-playing] {
+#playBtn:checked {
   align-self: stretch;
   border: var(--border);
   border-radius: var(--borderRad);
@@ -108,17 +108,33 @@ h2 {
   cursor: pointer;
 }
 
-[data-playing="false"] {
+#playBtn {
+  appearance: none;
+  width: 9vw;
+  height: 6vw;
+  min-width: 36px;
+  min-height: 36px;
+  max-width: 112px;
+  max-height: 64x;
+  margin: 0;
+  padding: 0;
+  border: var(--border);
+  border-radius: var(--borderRad);
   background: var(--pink) url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z" fill="black" /></svg>') no-repeat center center;
   background-size: 60% 60%;
   cursor: pointer;
 }
 
-[data-playing]:hover {
+#playBtn ~ label {
+  display: none;
+}
+
+#playBtn:hover,
+#playBtn:checked:hover {
   background-color: var(--yellow);
 }
 
-[data-playing="true"] {
+#playBtn:checked {
   background: var(--green) url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z" fill="black" /></svg>') no-repeat center center;
   background-size: 60% 60%;
 }
@@ -160,7 +176,8 @@ h2 {
   justify-content: space-between;
 }
 
-.pads button {
+.pads input {
+  appearance: none;
   width: 9vw;
   height: 9vw;
   min-width: 56px;
@@ -173,11 +190,11 @@ h2 {
   border: var(--border);
 }
 
-.pads button[aria-checked="true"] {
+.pads input:checked {
   background-color: var(--boxHigh);
 }
 
-.pads button span {
+.pads label {
   display: none;
 }
 


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the step-sequencer example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use literal string where possible

In addition
- Remove the antipattern: using `<button>`+ARIA instead of the semantic `<input type="checkbox">`
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
  - Improve instruction


Tested on Firefox, Safari, and Chrome (macOS) via a local server.