### PR TITLE
Update stereo-panner to modern JS

### DIFF
--- a/stereo-panner-node/index.html
+++ b/stereo-panner-node/index.html
@@ -1,67 +1,70 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-
-    <title>StereoPannerNode example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Web Audio API examples: StereoPannerNode</title>
   </head>
 
   <body>
-    <h1>StereoPannerNode example</h1>
+    <h1>Web Audio API examples: StereoPannerNode</h1>
     <audio controls>
-      <source src="viper.ogg" type="audio/ogg">
-      <source src="viper.mp3" type="audio/mp3">
-      <p>Browser too old to support HTML5 audio? How depressing!</p>
+      <source src="viper.ogg" type="audio/ogg" />
+      <source src="viper.mp3" type="audio/mp3" />
+      <p>This demo needs a browser supporting the &lt;audio&gt; element.</p>
     </audio>
     <h2>Set stereo panning</h2>
-    <input class="panning-control" type="range" min="-1" max="1" step="0.1" value="0">
+    <input
+      class="panning-control"
+      type="range"
+      min="-1"
+      max="1"
+      step="0.1"
+      value="0"
+    />
     <span class="panning-value">0</span>
-    <pre></pre>
+    <script>
+      // We cannot initialize it now, we need to do it after some user
+      // interaction.
+      let audioCtx;
+
+      // Useful UI elements
+      const audioElt = document.querySelector("audio");
+      const pre = document.querySelector("pre");
+
+      const panControl = document.querySelector(".panning-control");
+      const panValue = document.querySelector(".panning-value");
+
+      audioElt.addEventListener("play", () => {
+        // Create audio context if it doesn't already exist
+        // We can do this as their has been some user interaction
+        if (!audioCtx) {
+          audioCtx = new AudioContext();
+        }
+
+        // Create a MediaElementAudioSourceNode
+        // Feed the HTMLMediaElement into it
+        let source = new MediaElementAudioSourceNode(audioCtx, {
+          mediaElement: audioElt
+        });
+
+        // Create a stereo panner
+        let panNode = new StereoPannerNode(audioCtx);
+
+        // Event handler function to increase panning to the right and left
+        // when the slider is moved
+
+        panControl.oninput = () => {
+          panNode.pan.value = panControl.value;
+          panValue.textContent = panControl.value;
+        };
+
+        // connect the AudioBufferSourceNode to the gainNode
+        // and the gainNode to the destination, so we can play the
+        // music and adjust the panning using the controls
+        source.connect(panNode);
+        panNode.connect(audioCtx.destination);
+      });
+    </script>
   </body>
-<script>
-let audioCtx;
-const myAudio = document.querySelector('audio');
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-
-const panControl = document.querySelector('.panning-control');
-const panValue = document.querySelector('.panning-value');
-
-pre.innerHTML = myScript.innerHTML;
-
-myAudio.addEventListener('play', () => {
-  // Create audio context if it doesn't already exist
-  if(!audioCtx) {
-    audioCtx = new window.AudioContext();
-  }
-
-  // Create a MediaElementAudioSourceNode
-  // Feed the HTMLMediaElement into it
-  let source = audioCtx.createMediaElementSource(myAudio);
-
-  // Create a stereo panner
-  let panNode = audioCtx.createStereoPanner();
-
-  // Event handler function to increase panning to the right and left
-  // when the slider is moved
-
-  panControl.oninput = function() {
-    panNode.pan.value = panControl.value;
-    panValue.innerHTML = panControl.value;
-  }
-
-  // connect the AudioBufferSourceNode to the gainNode
-  // and the gainNode to the destination, so we can play the
-  // music and adjust the panning using the controls
-  source.connect(panNode);
-  panNode.connect(audioCtx.destination);
-})
-  </script>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the stereo-panner example:
- Use `const` and `let` where possible
- Use arrow functions where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
  - Improve instruction

Tested on Firefox, Safari, and Chrome (macOS) via a local server.