### PR TITLE
Update stream-source-buffer to modern JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The [step-sequencer](https://github.com/mdn/webaudio-examples/tree/master/step-s
 The [stereo-panner-node](https://github.com/mdn/webaudio-examples/tree/master/stereo-panner-node) directory contains a simple example to show how the Web Audio API [`StereoPannerNode`](https://developer.mozilla.org/en-US/docs/Web/API/StereoPannerNode) interface can be used to pan an audio stream. [Run the example live](http://mdn.github.io/webaudio-examples/stereo-panner-node/).
 
 ## Stream source buffer
-The [stream-source-buffer](https://github.com/mdn/webaudio-examples/tree/master/stream-source-buffer) directory contains a simple example demonstrating usage of the Web Audio API [`AudioContext.createMediaElementSource()`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaElementSource) method. [View example live](http://mdn.github.io/webaudio-examples/stream-source-buffer/).
+The [stream-source-buffer](https://github.com/mdn/webaudio-examples/tree/master/stream-source-buffer) directory contains a simple example demonstrating usage of the Web Audio API [`MediaStreamAudioSourceNode`](https://developer.mozilla.org/en-US/docs/Web/API/AMediaStreamAudioSourceNode) object. [View example live](http://mdn.github.io/webaudio-examples/stream-source-buffer/).
 
 ## Violent theremin
 

--- a/stereo-panner-node/index.html
+++ b/stereo-panner-node/index.html
@@ -1,67 +1,70 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-
-    <title>StereoPannerNode example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Web Audio API examples: StereoPannerNode</title>
   </head>
 
   <body>
-    <h1>StereoPannerNode example</h1>
+    <h1>Web Audio API examples: StereoPannerNode</h1>
     <audio controls>
-      <source src="viper.ogg" type="audio/ogg">
-      <source src="viper.mp3" type="audio/mp3">
-      <p>Browser too old to support HTML5 audio? How depressing!</p>
+      <source src="viper.ogg" type="audio/ogg" />
+      <source src="viper.mp3" type="audio/mp3" />
+      <p>This demo needs a browser supporting the &lt;audio&gt; element.</p>
     </audio>
     <h2>Set stereo panning</h2>
-    <input class="panning-control" type="range" min="-1" max="1" step="0.1" value="0">
+    <input
+      class="panning-control"
+      type="range"
+      min="-1"
+      max="1"
+      step="0.1"
+      value="0"
+    />
     <span class="panning-value">0</span>
-    <pre></pre>
+    <script>
+      // We cannot initialize it now, we need to do it after some user
+      // interaction.
+      let audioCtx;
+
+      // Useful UI elements
+      const audioElt = document.querySelector("audio");
+      const pre = document.querySelector("pre");
+
+      const panControl = document.querySelector(".panning-control");
+      const panValue = document.querySelector(".panning-value");
+
+      audioElt.addEventListener("play", () => {
+        // Create audio context if it doesn't already exist
+        // We can do this as their has been some user interaction
+        if (!audioCtx) {
+          audioCtx = new AudioContext();
+        }
+
+        // Create a MediaElementAudioSourceNode
+        // Feed the HTMLMediaElement into it
+        let source = new MediaElementAudioSourceNode(audioCtx, {
+          mediaElement: audioElt
+        });
+
+        // Create a stereo panner
+        let panNode = new StereoPannerNode(audioCtx);
+
+        // Event handler function to increase panning to the right and left
+        // when the slider is moved
+
+        panControl.oninput = () => {
+          panNode.pan.value = panControl.value;
+          panValue.textContent = panControl.value;
+        };
+
+        // connect the AudioBufferSourceNode to the gainNode
+        // and the gainNode to the destination, so we can play the
+        // music and adjust the panning using the controls
+        source.connect(panNode);
+        panNode.connect(audioCtx.destination);
+      });
+    </script>
   </body>
-<script>
-let audioCtx;
-const myAudio = document.querySelector('audio');
-const pre = document.querySelector('pre');
-const myScript = document.querySelector('script');
-
-const panControl = document.querySelector('.panning-control');
-const panValue = document.querySelector('.panning-value');
-
-pre.innerHTML = myScript.innerHTML;
-
-myAudio.addEventListener('play', () => {
-  // Create audio context if it doesn't already exist
-  if(!audioCtx) {
-    audioCtx = new window.AudioContext();
-  }
-
-  // Create a MediaElementAudioSourceNode
-  // Feed the HTMLMediaElement into it
-  let source = audioCtx.createMediaElementSource(myAudio);
-
-  // Create a stereo panner
-  let panNode = audioCtx.createStereoPanner();
-
-  // Event handler function to increase panning to the right and left
-  // when the slider is moved
-
-  panControl.oninput = function() {
-    panNode.pan.value = panControl.value;
-    panValue.innerHTML = panControl.value;
-  }
-
-  // connect the AudioBufferSourceNode to the gainNode
-  // and the gainNode to the destination, so we can play the
-  // music and adjust the panning using the controls
-  source.connect(panNode);
-  panNode.connect(audioCtx.destination);
-})
-  </script>
 </html>

--- a/stream-source-buffer/index.html
+++ b/stream-source-buffer/index.html
@@ -1,95 +1,83 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-
-    <title>createMediaStreamSource example</title>
-
-    <link rel="stylesheet" href="">
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Web Audio API examples: MediaStreamAudioSourceNode</title>
   </head>
 
   <body>
-    <h1>createMediaStreamSource example</h1>
-    <video controls>
-    </video>
-    <br>
-    <input type="range" min="1" max="40">
+    <h1>Web Audio API examples: MediaStreamAudioSourceNode</h1>
+    <video controls></video>
+    <br />
+    <label for="gain">Volume: </label><input id="gain" type="range" min="1" max="40" />
 
-    <pre></pre>
+    <p>Biquad filter frequency response for:</p>
+    <ul class="freq-response"></ul>
+    <script>
+      // Store useful UI elements
+      const video = document.querySelector("video");
+      const range = document.querySelector("#gain");
+      const freqResponseOutput = document.querySelector(".freq-response");
 
-    <p>Biquad filter frequency response for: </p>
-    <ul class="freq-response-output">
-    </ul>
-  </body>
-<script>
-const myAudio = document.querySelector('audio');
-const pre = document.querySelector('pre');
-const video = document.querySelector('video');
-const myScript = document.querySelector('script');
-const range = document.querySelector('input');
-const freqResponseOutput = document.querySelector('.freq-response-output');
-// create float32 arrays for getFrequencyResponse
-const myFrequencyArray = new Float32Array(5);
-myFrequencyArray[0] = 1000;
-myFrequencyArray[1] = 2000;
-myFrequencyArray[2] = 3000;
-myFrequencyArray[3] = 4000;
-myFrequencyArray[4] = 5000;
-const magResponseOutput = new Float32Array(5);
-const phaseResponseOutput = new Float32Array(5);
-// getUserMedia block - grab stream
-// put it into a MediaStreamAudioSourceNode
-// also output the visuals into a video element
-if (navigator.mediaDevices) {
-    console.log('getUserMedia supported.');
-    navigator.mediaDevices.getUserMedia ({audio: true, video: true})
-    .then(function(stream) {
-        video.srcObject = stream;
-        video.onloadedmetadata = function(e) {
+      // Create float32 arrays for getFrequencyResponse()
+      const frequencyArray = new Float32Array([1000, 2000, 3000, 4000, 5000]);
+      const magResponseOutput = new Float32Array(frequencyArray.length);
+      const phaseResponseOutput = new Float32Array(frequencyArray.length);
+
+      navigator.mediaDevices
+        .getUserMedia({ audio: true, video: true })
+        .then((stream) => {
+          video.srcObject = stream;
+          video.onloadedmetadata = (e) => {
             video.play();
             video.muted = true;
-        };
-        // Create a MediaStreamAudioSourceNode
-        // Feed the HTMLMediaElement into it
-        const audioCtx = new AudioContext();
-        const source = audioCtx.createMediaStreamSource(stream);
-        // Create a biquadfilter
-        const biquadFilter = audioCtx.createBiquadFilter();
-        biquadFilter.type = "lowshelf";
-        biquadFilter.frequency.value = 1000;
-        biquadFilter.gain.value = range.value;
-        // connect the AudioBufferSourceNode to the gainNode
-        // and the gainNode to the destination, so we can play the
-        // music and adjust the volume using the mouse cursor
-        source.connect(biquadFilter);
-        biquadFilter.connect(audioCtx.destination);
-        // Get new mouse pointer coordinates when mouse is moved
-        // then set new gain value
-        range.oninput = function() {
+          };
+
+          // Create a MediaStreamAudioSourceNode
+          // Feed the HTMLMediaElement into it
+          const audioCtx = new AudioContext();
+          const source = new MediaStreamAudioSourceNode(audioCtx, {
+            mediaStream: stream,
+          });
+
+          // Create a biquadfilter
+          const biquadFilter = new BiquadFilterNode(audioCtx, {
+            type: "lowshelf",
+            frequency: 1000,
+            gain: range.value,
+          });
+
+          // Chain the nodes so we can play the
+          // music and adjust the volume using the mouse cursor
+          source.connect(biquadFilter);
+          biquadFilter.connect(audioCtx.destination);
+
+          // Get new mouse pointer coordinates when mouse is moved
+          // then set new gain value
+          range.oninput = () => {
             biquadFilter.gain.value = range.value;
-        }
-        function calcFrequencyResponse() {
-            biquadFilter.getFrequencyResponse(myFrequencyArray,magResponseOutput,phaseResponseOutput);
-            for (i = 0; i <= myFrequencyArray.length-1;i++){
-                let listItem = document.createElement('li');
-                listItem.innerHTML = '<strong>' + myFrequencyArray[i] + 'Hz</strong>: Magnitude ' + magResponseOutput[i] + ', Phase ' + phaseResponseOutput[i] + ' radians.';
-                freqResponseOutput.appendChild(listItem);
-            }
-        }
-        calcFrequencyResponse();
-    })
-    .catch(function(err) {
-        console.log('The following gUM error occured: ' + err);
-    });
-} else {
-    console.log('getUserMedia not supported on your browser!');
-}
-// dump script to pre element
-pre.innerHTML = myScript.innerHTML;
-</script>
+          };
+
+          // Read frequency response:
+
+          // Get magnitude and phase associated with a frequency
+          biquadFilter.getFrequencyResponse(
+            frequencyArray,
+            magResponseOutput,
+            phaseResponseOutput
+          );
+
+          // Populate list
+          for (let i = 0; i < frequencyArray.length; i++) {
+            const listItem = document.createElement("li");
+            listItem.textContent = `${frequencyArray[i]}Hz: Magnitude ${magResponseOutput[i]}, Phase ${phaseResponseOutput[i]}rad.`;
+            freqResponseOutput.appendChild(listItem);
+          }
+        })
+        .catch((err) => {
+          console.error(`The following error occured: ${err}`);
+        });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This is part of our project to update code to a more modern JS syntax.

This PR updates the spatialization example:
- Use `const` and `let` where possible
- Use arrow functions where possible
- Use literal string where possible

In addition:
- Use now the unprefixed version of Web Audio API only (ubiquitous and prefixed versions are not supported by browsers anymore)
- Use constructors instead of factory methods
- Pass Prettier
- Fix the HTML code:
  - Declare the language
  - Fix the title
  - Improve instruction
- Fix `README.md`
- Some other JS cleaning to make the code more resilient to edition
- Fixes comments

Tested on Firefox, Safari, and Chrome (macOS) via a local server.