### PR TITLE
Fix AudioBuffer constructor

### DIFF
--- a/audio-buffer/index.html
+++ b/audio-buffer/index.html
@@ -31,7 +31,7 @@
       // sample rate of the AudioContext
       const frameCount = audioCtx.sampleRate * 2.0;
 
-      const buffer = new AudioBuffer(audioCtx, {
+      const buffer = new AudioBuffer({
         numberOfChannels: channels,
         length: frameCount,
         sampleRate: audioCtx.sampleRate,


### PR DESCRIPTION
Removed additional parameter to AudioBuffer constructor, it expects only AudioBuffer options.