### PR TITLE
Issue #112 Fix: Updates Noise Dur Slider value assignment

### DIFF
--- a/step-sequencer/index.html
+++ b/step-sequencer/index.html
@@ -130,10 +130,10 @@
               name="duration"
               id="duration"
               type="range"
-              min="0"
-              max="2"
+              min="0.25"
+              max="1"
               value="1"
-              step="0.1"
+              step="0.25"
             />
             <label for="band">Band</label>
             <input
@@ -304,7 +304,7 @@
       durControl.addEventListener(
         "input",
         (ev) => {
-          noiseDuration = parseInt(ev.target.value, 10);
+          noiseDuration = ev.target.value;
         },
         false
       );

--- a/step-sequencer/index.html
+++ b/step-sequencer/index.html
@@ -304,7 +304,7 @@
       durControl.addEventListener(
         "input",
         (ev) => {
-          noiseDuration = ev.target.value;
+          noiseDuration = parseFloat(ev.target.value);
         },
         false
       );


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Slider position values attenuated by `parseInt` result in possible duration values: `0`, `1`, `2`. All slider positions left of the midpoint result in a value of `0` and cause the uncaught error described in issue #112 

New slider position values of `0.25`, `0.5`, `0.75`, and `1` resolve this bug. Additionally they provide a user experience reflective of traditional musical principles: the new slider duration values are equivalent to sixteenth, eighth, dotted-eighth, and quarter note durations.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

Uncaught DOM exception error described in issue #112 

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

fixes #112 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
