### PR TITLE
panner-node: Script doesn't load as the DOM is not ready

### DIFF
--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -12,7 +12,6 @@
       type="text/css"
     />
     <link rel="stylesheet" href="style.css" />
-    <script src="main.js"></script>
   </head>
 
   <body>
@@ -60,5 +59,6 @@
         >Adam Whitcroft</a
       >
     </p>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/panner-node/index.html
+++ b/panner-node/index.html
@@ -12,6 +12,7 @@
       type="text/css"
     />
     <link rel="stylesheet" href="style.css" />
+    <script src="main.js" defer></script>
   </head>
 
   <body>
@@ -59,6 +60,5 @@
         >Adam Whitcroft</a
       >
     </p>
-    <script src="main.js"></script>
   </body>
 </html>


### PR DESCRIPTION

### Description

The `main.js` should load after the DOM structure to make querySelector work correctly

### Motivation

The online [demo](https://mdn.github.io/webaudio-examples/panner-node/) runs failed

### Additional details

None

### Related issues and pull requests

None
