### PR TITLE
fix: correct error variable name

### DIFF
--- a/voice-change-o-matic/scripts/app.js
+++ b/voice-change-o-matic/scripts/app.js
@@ -51,7 +51,7 @@ async function init() {
     const arrayBuffer = await response.arrayBuffer();
     const decodedAudio = await audioCtx.decodeAudioData(arrayBuffer);
     convolver.buffer = decodedAudio;
-  } catch (error) {
+  } catch (err) {
     console.error(
       `Unable to fetch the audio file: ${name} Error: ${err.message}`
     );

--- a/voice-change-o-matic/scripts/app.js
+++ b/voice-change-o-matic/scripts/app.js
@@ -51,9 +51,9 @@ async function init() {
     const arrayBuffer = await response.arrayBuffer();
     const decodedAudio = await audioCtx.decodeAudioData(arrayBuffer);
     convolver.buffer = decodedAudio;
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `Unable to fetch the audio file: ${name} Error: ${err.message}`
+      `Unable to fetch the audio file: ${name} Error: ${error.message}`
     );
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

When decoding fails, the error log crashes the app due to mis-named error variable.

### Motivation

Allows the actual error to be logged instead of crashing the app.

### Additional details

N/A

### Related issues and pull requests

N/A
