### PR TITLE
Fix: Implement touch events in violent theremin demo

### DIFF
--- a/violent-theremin/index.html
+++ b/violent-theremin/index.html
@@ -8,9 +8,10 @@
     <link href="styles/app.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
-    <p class="start-message">
-      Click on the browser window or press the tab key to start the app.
-    </p>
+    <button class="start-message">
+      Click anywhere in the browser window <br />
+      to start the app.
+    </button>
 
     <div class="app-contents">
       <h1>Violent Theremin</h1>

--- a/violent-theremin/scripts/app.js
+++ b/violent-theremin/scripts/app.js
@@ -3,20 +3,29 @@ const startMessage = document.querySelector(".start-message");
 let isAppInit = false;
 appContents.style.display = "none";
 
-window.addEventListener("keydown", init);
-window.addEventListener("click", init);
+startMessage.addEventListener("click", transitionScreen);
 
-function init() {
-  if (isAppInit) {
-    return;
-  }
-
-  appContents.style.display = "block";
-  document.body.removeChild(startMessage);
-
+function transitionScreen() {
   // create web audio api context
   const AudioContext = window.AudioContext || window.webkitAudioContext;
   const audioCtx = new AudioContext();
+
+  // remove start message button element and show app contents
+  appContents.style.display = "block";
+  document.body.removeChild(startMessage);
+
+  init(audioCtx);
+}
+
+/**
+ * Initializes the audio context and sets up the theremin functionality
+ *
+ * @param {AudioContext} audioCtx - The Web Audio API AudioContext used to generate and manipulate audio signals
+ */
+function init(audioCtx) {
+  if (isAppInit) {
+    return;
+  }
 
   // create Oscillator and gain node
   const oscillator = audioCtx.createOscillator();
@@ -49,6 +58,18 @@ function init() {
   // Mouse pointer coordinates
   let CurX;
   let CurY;
+
+  document.addEventListener("mousemove", updatePage);
+  document.addEventListener(
+    "touchmove",
+    (e) => {
+      // prevent scrolling
+      e.preventDefault();
+      // use first touch point for mouse coordinates
+      updatePage(e.touches[0]);
+    },
+    { passive: false }
+  );
 
   // Get new mouse pointer coordinates when mouse is moved
   // then set new gain and pitch values

--- a/violent-theremin/styles/app.css
+++ b/violent-theremin/styles/app.css
@@ -28,7 +28,7 @@ h1 {
 
 /* button styling */
 
-button {
+button:not(.start-message) {
   background-color: #0088cc;
   background-image: linear-gradient(to bottom, #0088cc 0%, #0055cc 100%);
   text-shadow: 1px 1px 1px black;
@@ -48,13 +48,13 @@ button {
   position: absolute;
 }
 
-button:hover,
-button:focus {
+button:not(.start-message):hover,
+button:not(.start-message):focus {
   box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.7);
   opacity: 1;
 }
 
-button:active {
+button:not(.start-message):active {
   box-shadow: inset 2px 2px 3px rgba(0, 0, 0, 0.7);
 }
 
@@ -71,6 +71,20 @@ button:active {
 .clear {
   top: 6px;
   left: 5px;
+}
+
+.start-message {
+  all: unset;
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+  cursor: pointer;
+  font-size: 50px;
+  text-align: center;
+  overflow: hidden;
 }
 
 .start-message {


### PR DESCRIPTION
This PR resolves [issue #126](https://github.com/mdn/webaudio-examples/issues/126) by enabling [touch events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events) in the [Violent Theremin demo](https://github.com/mdn/webaudio-examples/tree/main/violent-theremin), making the [example](https://mdn.github.io/webaudio-examples/violent-theremin/) usable on mobile device web browsers.

---

### **Changes Introduced in This PR**  

1. **Replaces `<p>` with `<button>` for the start message:**  
   - Mobile web browsers enforce stricter protocols for requiring an `AudioContext` to be [initialized via a user gesture](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy), such as a button click. This migration allows the `AudioContext` to run on mobile devices and avoids the following console warning:
     <img width="720" alt="Screenshot 2024-10-15 at 5 38 27 PM" src="https://github.com/user-attachments/assets/64ef544e-50c2-43a1-9bc6-63174814211e">
   - The `.start-message` button is styled to cover the full screen, closely mimicking the previous `<p>` element while keeping the text centered.  

2. **Prevents duplicate `init()` invocations:**  
   - Ensures the `init()` method is called only once by removing redundant `keydown` event listeners and triggering `init()` exclusively on the `.start-message` button click.  
   - Since the `init()` method already configures keyboard controls, removing `window.addEventListener("keydown", init);` did not impact the functionality.  
   - This change aligns with feedback from @normanr in https://github.com/mdn/sprints/issues/3937#issuecomment-737473301.  

3. **Prevents scrolling on `touchmove` events:**  
   - Disables scrolling caused by touch gestures to maintain functionality on touch screens.  
   - Registers the `updatePage()` method as a callback for `touchmove` events within the `init()` method.  

---

This PR allows the example to function seamlessly on both **desktop and mobile browsers**, providing a consistent and smooth experience across devices.  