### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
